### PR TITLE
feat(search): add --json flag for AI agent integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,9 @@ grepai search "user authentication flow"
 grepai search "error handling middleware"
 grepai search "database connection pool"
 grepai search "API request validation"
+
+# JSON output for programmatic use (recommended for AI agents)
+grepai search "authentication flow" --json
 ```
 
 ### Query Tips

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ grepai trace callers "Login"       # Find who calls a function
 
 ```bash
 grepai search "authentication" -n 5  # Limit results (default: 10)
+grepai search "authentication" --json  # JSON output for AI agents
 ```
 
 ### Call Graph Analysis

--- a/cli/agent_setup.go
+++ b/cli/agent_setup.go
@@ -40,6 +40,9 @@ grepai search "user authentication flow"
 grepai search "error handling middleware"
 grepai search "database connection pool"
 grepai search "API request validation"
+
+# JSON output for programmatic use (recommended for AI agents)
+grepai search "authentication flow" --json
 ` + "```" + `
 
 ### Query Tips

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -45,6 +45,9 @@ grepai search "REST API routes"
 
 # Limit results
 grepai search "database queries" --limit 10
+
+# JSON output for AI agents
+grepai search "authentication" --json
 ```
 
 ## 4. Check Index Status


### PR DESCRIPTION
## Summary
- Add `--json`/`-j` flag to `grepai search` command for machine-readable output
- JSON output excludes internal fields (vector, hash, updated_at) to minimize token usage
- Error handling outputs JSON format when flag is used

## Test plan
- [x] Build passes (`make build`)
- [x] Tests pass (`make test`)
- [x] Manual testing with `grepai search "query" --json`
- [x] JSON validation with `jq`

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)