### PR TITLE
feat(cli): add trace command instructions to agent-setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ Follow conventional commits: `type(scope): description`
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 
 
+
+
 ## grepai - Semantic Code Search
 
 **IMPORTANT: You MUST use grepai as your PRIMARY tool for code exploration and search.**
@@ -80,7 +82,6 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 ### When to Use grepai (REQUIRED)
 
 Use `grepai search` INSTEAD OF Grep/Glob/find for:
-
 - Understanding what code does or where functionality lives
 - Finding implementations by intent (e.g., "authentication logic", "error handling")
 - Exploring unfamiliar parts of the codebase
@@ -89,7 +90,6 @@ Use `grepai search` INSTEAD OF Grep/Glob/find for:
 ### When to Use Standard Tools
 
 Only use Grep/Glob when you need:
-
 - Exact text matching (variable names, imports, specific strings)
 - File path patterns (e.g., `**/*.go`)
 
@@ -117,8 +117,32 @@ grepai search "authentication flow" --json
 - **Be specific**: "JWT token validation" better than "token"
 - Results include: file path, line numbers, relevance score, code preview
 
+### Call Graph Tracing
+
+Use `grepai trace` to understand function relationships:
+- Finding all callers of a function before modifying it
+- Understanding what functions are called by a given function
+- Visualizing the complete call graph around a symbol
+
+#### Trace Commands
+
+**IMPORTANT: Always use `--json` flag for optimal AI agent integration.**
+
+```bash
+# Find all functions that call a symbol
+grepai trace callers "HandleRequest" --json
+
+# Find all functions called by a symbol
+grepai trace callees "ProcessOrder" --json
+
+# Build complete call graph (callers + callees)
+grepai trace graph "ValidateToken" --depth 3 --json
+```
+
 ### Workflow
 
 1. Start with `grepai search` to find relevant code
-2. Use `Read` tool to examine files from results
-3. Only use Grep for exact string searches if needed
+2. Use `grepai trace` to understand function relationships
+3. Use `Read` tool to examine files from results
+4. Only use Grep for exact string searches if needed
+

--- a/cli/agent_setup.go
+++ b/cli/agent_setup.go
@@ -52,11 +52,34 @@ grepai search "authentication flow" --json
 - **Be specific**: "JWT token validation" better than "token"
 - Results include: file path, line numbers, relevance score, code preview
 
+### Call Graph Tracing
+
+Use ` + "`grepai trace`" + ` to understand function relationships:
+- Finding all callers of a function before modifying it
+- Understanding what functions are called by a given function
+- Visualizing the complete call graph around a symbol
+
+#### Trace Commands
+
+**IMPORTANT: Always use ` + "`--json`" + ` flag for optimal AI agent integration.**
+
+` + "```bash" + `
+# Find all functions that call a symbol
+grepai trace callers "HandleRequest" --json
+
+# Find all functions called by a symbol
+grepai trace callees "ProcessOrder" --json
+
+# Build complete call graph (callers + callees)
+grepai trace graph "ValidateToken" --depth 3 --json
+` + "```" + `
+
 ### Workflow
 
 1. Start with ` + "`grepai search`" + ` to find relevant code
-2. Use ` + "`Read`" + ` tool to examine files from results
-3. Only use Grep for exact string searches if needed
+2. Use ` + "`grepai trace`" + ` to understand function relationships
+3. Use ` + "`Read`" + ` tool to examine files from results
+4. Only use Grep for exact string searches if needed
 
 `
 


### PR DESCRIPTION
## Summary

- Add documentation for the `trace` command (callers, callees, graph) in agent instructions
- All trace examples include `--json` flag for optimal AI agent integration
- Update workflow section to include trace as step 2 for understanding function relationships

## Related Issue

Closes #16

## Test plan

- [x] Build passes (`make build`)
- [x] Tests pass (`make test`)
- [x] Tested `agent-setup` command on this project
- [x] Verified new instructions appear in CLAUDE.md with trace commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)