### PR TITLE
feat(trace): add Java language support for symbol extraction and call graph

### DIFF
--- a/cli/watch.go
+++ b/cli/watch.go
@@ -146,7 +146,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	// Use default trace languages if not configured
 	tracedLanguages := cfg.Trace.EnabledLanguages
 	if len(tracedLanguages) == 0 {
-		tracedLanguages = []string{".go", ".js", ".ts", ".jsx", ".tsx", ".py", ".php"}
+		tracedLanguages = []string{".go", ".js", ".ts", ".jsx", ".tsx", ".py", ".php", ".java"}
 	}
 
 	// Initial scan with progress

--- a/docs/src/content/docs/trace.md
+++ b/docs/src/content/docs/trace.md
@@ -12,7 +12,7 @@ description: Analyze function relationships with grepai trace
 - **Find callers**: Discover which functions call a specific symbol
 - **Find callees**: See what functions a symbol calls
 - **Build call graphs**: Visualize call relationships with configurable depth
-- **Multi-language support**: Go, TypeScript/JavaScript, Python, PHP
+- **Multi-language support**: Go, TypeScript/JavaScript, Python, PHP, Java, C/C++, Rust, Zig
 - **Two extraction modes**: Fast (regex) and Precise (tree-sitter AST)
 - **JSON output**: Perfect for AI agents and automation
 
@@ -67,6 +67,7 @@ grepai trace callers "MyFunction" --mode precise
 | JavaScript | `.js`, `.jsx` | Excellent |
 | Python | `.py` | Good |
 | PHP | `.php` | Good |
+| Java | `.java` | Good |
 | C | `.c`, `.h` | Good |
 | C++ | `.cpp`, `.hpp`, `.cc`, `.cxx`, `.hxx` | Good |
 | Zig | `.zig` | Good |
@@ -113,6 +114,7 @@ trace:
     - .tsx
     - .py
     - .php
+    - .java
     - .c
     - .h
     - .cpp


### PR DESCRIPTION
## Summary

Add comprehensive Java language support to the trace/call graph feature, enabling symbol extraction and call graph analysis for Java codebases.

## Changes

- **`trace/patterns.go`**: Define `javaPatterns` with regex for:
  - Classes (with extends/implements, generics, sealed/non-sealed)
  - Inner/nested classes
  - Interfaces (including @interface annotations)
  - Enums (top-level and inner)
  - Records (Java 14+)
  - Methods with all modifiers (public, protected, private, static, final, abstract, synchronized, native, strictfp)
  - Constructors
  - Default interface methods (Java 8+)
  - Abstract methods
  - Java keywords added to `languageKeywords` for filtering

- **`cli/watch.go`**: Add `.java` to default traced languages

- **`trace/extractor_test.go`**: Comprehensive test covering all Java constructs

- **`docs/src/content/docs/trace.md`**: Update documentation with Java support

## Test Plan

- [x] `make lint` passes
- [x] `make test` passes (all tests including new Java tests)
- [x] `make build` succeeds
- [x] Tested symbol extraction on real Java file with classes, interfaces, enums, records, methods

## Related Issue

Closes #32

---
🤖 Generated with [Claude Code](https://claude.ai/code)