### PR TITLE
fix(config): add external_gitignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ search:
     enabled: true           # Structural boosting for better relevance
 trace:
   mode: fast                # fast (regex) | precise (tree-sitter)
+external_gitignore: ""      # Path to external gitignore (e.g., ~/.config/git/ignore)
 ```
 
 > **Note**: Old configs without `endpoint` or `dimensions` are automatically updated with sensible defaults.

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -120,7 +120,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	defer st.Close()
 
 	// Initialize ignore matcher
-	ignoreMatcher, err := indexer.NewIgnoreMatcher(projectRoot, cfg.Ignore)
+	ignoreMatcher, err := indexer.NewIgnoreMatcher(projectRoot, cfg.Ignore, cfg.ExternalGitignore)
 	if err != nil {
 		return fmt.Errorf("failed to initialize ignore matcher: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -16,15 +16,16 @@ const (
 )
 
 type Config struct {
-	Version  int            `yaml:"version"`
-	Embedder EmbedderConfig `yaml:"embedder"`
-	Store    StoreConfig    `yaml:"store"`
-	Chunking ChunkingConfig `yaml:"chunking"`
-	Watch    WatchConfig    `yaml:"watch"`
-	Search   SearchConfig   `yaml:"search"`
-	Trace    TraceConfig    `yaml:"trace"`
-	Update   UpdateConfig   `yaml:"update"`
-	Ignore   []string       `yaml:"ignore"`
+	Version           int            `yaml:"version"`
+	Embedder          EmbedderConfig `yaml:"embedder"`
+	Store             StoreConfig    `yaml:"store"`
+	Chunking          ChunkingConfig `yaml:"chunking"`
+	Watch             WatchConfig    `yaml:"watch"`
+	Search            SearchConfig   `yaml:"search"`
+	Trace             TraceConfig    `yaml:"trace"`
+	Update            UpdateConfig   `yaml:"update"`
+	Ignore            []string       `yaml:"ignore"`
+	ExternalGitignore string         `yaml:"external_gitignore,omitempty"`
 }
 
 // UpdateConfig holds auto-update settings

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -84,6 +84,10 @@ ignore:
   - "target"
   - ".zig-cache"
   - "zig-out"
+
+# Path to an external gitignore file (e.g., global gitignore)
+# Supports ~ expansion for home directory
+external_gitignore: "~/.config/git/ignore"
 ```
 
 ## Embedder Options
@@ -227,6 +231,24 @@ search:
 ```
 
 See [Hybrid Search](/grepai/hybrid-search/) for full documentation.
+
+## External Gitignore
+
+You can specify an external gitignore file (such as your global Git ignore file) to be respected during indexing:
+
+```yaml
+external_gitignore: "~/.config/git/ignore"
+```
+
+This is useful for ignoring files globally configured in Git (e.g., IDE files, OS-specific files).
+
+Common locations for global gitignore:
+- `~/.config/git/ignore` (XDG standard)
+- `~/.gitignore_global` (older convention)
+
+The tilde (`~`) is automatically expanded to your home directory.
+
+If the file doesn't exist, grepai will log a warning and continue without it.
 
 ## Environment Variables
 

--- a/indexer/scanner_test.go
+++ b/indexer/scanner_test.go
@@ -40,7 +40,7 @@ func TestScanner_Scan(t *testing.T) {
 	}
 
 	// Create ignore matcher
-	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{})
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
 	if err != nil {
 		t.Fatalf("failed to create ignore matcher: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestScanner_IgnoreBinaryFiles(t *testing.T) {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
-	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{})
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
 	if err != nil {
 		t.Fatalf("failed to create ignore matcher: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestScanner_IgnoreUnsupportedExtensions(t *testing.T) {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
-	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{})
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
 	if err != nil {
 		t.Fatalf("failed to create ignore matcher: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestScanner_ScanFile(t *testing.T) {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
-	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{})
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
 	if err != nil {
 		t.Fatalf("failed to create ignore matcher: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestScanner_SkipsMinifiedFiles(t *testing.T) {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
-	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{})
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
 	if err != nil {
 		t.Fatalf("failed to create ignore matcher: %v", err)
 	}
@@ -294,7 +294,7 @@ func TestScanner_ScanFile_SkipsMinified(t *testing.T) {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
-	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{})
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
 	if err != nil {
 		t.Fatalf("failed to create ignore matcher: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Add `external_gitignore` configuration option to specify a path to an external gitignore file (e.g., `~/.config/git/ignore`)
- Support tilde (`~`) expansion for home directory paths
- External gitignore patterns are respected during indexing alongside project-level `.gitignore` files
- If the external file doesn't exist, a warning is logged but indexing continues normally

## Test plan
- [x] Unit tests for `expandTilde()` function
- [x] Unit tests for `NewIgnoreMatcher()` with external gitignore
- [x] Unit tests for non-existent external gitignore (graceful handling)
- [x] Manual test: created `/tmp/test-external-gitignore` with `*.testpattern`, verified files matching the pattern are ignored
- [x] All existing tests pass with updated function signature
- [x] Lint passes

## Changes
| File | Changes |
|------|---------|
| `config/config.go` | Add `ExternalGitignore` field to Config struct |
| `indexer/gitignore.go` | Add `expandTilde()` function, modify `NewIgnoreMatcher()` |
| `cli/watch.go` | Pass external gitignore path to `NewIgnoreMatcher()` |
| `indexer/gitignore_test.go` | Add tests for new functionality |
| `indexer/scanner_test.go` | Update tests for new function signature |
| `README.md` | Document new configuration option |
| `docs/src/content/docs/configuration.md` | Add detailed documentation |

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)