### PR TITLE
refactor(watcher): no more useless embedding, new config watcher.last…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -77,7 +78,8 @@ type ChunkingConfig struct {
 }
 
 type WatchConfig struct {
-	DebounceMs int `yaml:"debounce_ms"`
+	DebounceMs    int       `yaml:"debounce_ms"`
+	LastIndexTime time.Time `yaml:"last_index_time,omitempty"`
 }
 
 type TraceConfig struct {

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -1,0 +1,482 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/yoanbernabeu/grepai/store"
+)
+
+// mockStore implements store.VectorStore for testing
+type mockStore struct {
+	documents        map[string]store.Document
+	chunks           map[string]store.Chunk
+	listFilesStats   []store.FileStats
+	listDocsCalled   bool
+	getDocCalled     bool
+	saveDocCalled    bool
+	saveChunksCalled bool
+	delByFileCalled  bool
+	delDocCalled     bool
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{
+		documents: make(map[string]store.Document),
+		chunks:    make(map[string]store.Chunk),
+	}
+}
+
+func (m *mockStore) SaveChunks(ctx context.Context, chunks []store.Chunk) error {
+	m.saveChunksCalled = true
+	for _, chunk := range chunks {
+		m.chunks[chunk.ID] = chunk
+	}
+	return nil
+}
+
+func (m *mockStore) DeleteByFile(ctx context.Context, filePath string) error {
+	m.delByFileCalled = true
+	doc, ok := m.documents[filePath]
+	if !ok {
+		return nil
+	}
+	for _, chunkID := range doc.ChunkIDs {
+		delete(m.chunks, chunkID)
+	}
+	return nil
+}
+
+func (m *mockStore) Search(ctx context.Context, queryVector []float32, limit int) ([]store.SearchResult, error) {
+	results := make([]store.SearchResult, 0, len(m.chunks))
+	for _, chunk := range m.chunks {
+		results = append(results, store.SearchResult{
+			Chunk: chunk,
+			Score: 1.0,
+		})
+	}
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
+}
+
+func (m *mockStore) GetDocument(ctx context.Context, filePath string) (*store.Document, error) {
+	m.getDocCalled = true
+	doc, ok := m.documents[filePath]
+	if !ok {
+		return nil, nil
+	}
+	return &doc, nil
+}
+
+func (m *mockStore) SaveDocument(ctx context.Context, doc store.Document) error {
+	m.saveDocCalled = true
+	m.documents[doc.Path] = doc
+	return nil
+}
+
+func (m *mockStore) DeleteDocument(ctx context.Context, filePath string) error {
+	m.delDocCalled = true
+	delete(m.documents, filePath)
+	return nil
+}
+
+func (m *mockStore) ListDocuments(ctx context.Context) ([]string, error) {
+	m.listDocsCalled = true
+	paths := make([]string, 0, len(m.documents))
+	for path := range m.documents {
+		paths = append(paths, path)
+	}
+	return paths, nil
+}
+
+func (m *mockStore) Load(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockStore) Persist(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockStore) Close() error {
+	return nil
+}
+
+func (m *mockStore) GetStats(ctx context.Context) (*store.IndexStats, error) {
+	return &store.IndexStats{
+		TotalFiles:  len(m.documents),
+		TotalChunks: len(m.chunks),
+	}, nil
+}
+
+func (m *mockStore) ListFilesWithStats(ctx context.Context) ([]store.FileStats, error) {
+	stats := make([]store.FileStats, 0, len(m.documents))
+	for _, doc := range m.documents {
+		stats = append(stats, store.FileStats{
+			Path:       doc.Path,
+			ChunkCount: len(doc.ChunkIDs),
+			ModTime:    doc.ModTime,
+		})
+	}
+	// If listFilesStats is set, use that instead (for testing)
+	if len(m.listFilesStats) > 0 {
+		return m.listFilesStats, nil
+	}
+	return stats, nil
+}
+
+func (m *mockStore) GetChunksForFile(ctx context.Context, filePath string) ([]store.Chunk, error) {
+	doc, ok := m.documents[filePath]
+	if !ok {
+		return nil, nil
+	}
+	chunks := make([]store.Chunk, 0, len(doc.ChunkIDs))
+	for _, id := range doc.ChunkIDs {
+		if chunk, ok := m.chunks[id]; ok {
+			chunks = append(chunks, chunk)
+		}
+	}
+	return chunks, nil
+}
+
+func (m *mockStore) GetAllChunks(ctx context.Context) ([]store.Chunk, error) {
+	chunks := make([]store.Chunk, 0, len(m.chunks))
+	for _, chunk := range m.chunks {
+		chunks = append(chunks, chunk)
+	}
+	return chunks, nil
+}
+
+// mockEmbedder implements embedder.Embedder for testing
+type mockEmbedder struct {
+	embedCalled bool
+}
+
+func newMockEmbedder() *mockEmbedder {
+	return &mockEmbedder{}
+}
+
+func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	m.embedCalled = true
+	return []float32{0.1, 0.2, 0.3}, nil
+}
+
+func (m *mockEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	m.embedCalled = true
+	vectors := make([][]float32, len(texts))
+	for i := range texts {
+		vectors[i] = []float32{0.1, 0.2, 0.3}
+	}
+	return vectors, nil
+}
+
+func (m *mockEmbedder) Dimensions() int {
+	return 3
+}
+
+func (m *mockEmbedder) Close() error {
+	return nil
+}
+
+// TestIndexAllWithProgress_UnchangedFilesSkipped tests that files with matching ModTimes are skipped
+func TestIndexAllWithProgress_UnchangedFilesSkipped(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create test file
+	testFile := filepath.Join(tmpDir, "test.go")
+	content := "package main\n\nfunc main() {}"
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// Get file ModTime
+	fileInfo, err := os.Stat(testFile)
+	if err != nil {
+		t.Fatalf("failed to get file info: %v", err)
+	}
+	fileModTime := time.Unix(fileInfo.ModTime().Unix(), 0)
+
+	// Create mock store with existing file that has matching ModTime
+	mockStore := newMockStore()
+	mockStore.documents["test.go"] = store.Document{
+		Path:     "test.go",
+		Hash:     "hash123",
+		ModTime:  fileModTime,
+		ChunkIDs: []string{"chunk1"},
+	}
+
+	// Create indexer with lastIndexTime set to now to enable ModTime-based skipping
+	mockEmbedder := newMockEmbedder()
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
+	if err != nil {
+		t.Fatalf("failed to create ignore matcher: %v", err)
+	}
+	scanner := NewScanner(tmpDir, ignoreMatcher)
+	chunker := NewChunker(512, 50)
+	indexer := NewIndexer(tmpDir, mockStore, mockEmbedder, chunker, scanner, time.Now())
+
+	// Index with progress
+	stats, err := indexer.IndexAllWithProgress(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("IndexAllWithProgress failed: %v", err)
+	}
+
+	// Assert: No files should be indexed (all skipped by ModTime)
+	if stats.FilesIndexed != 0 {
+		t.Errorf("expected 0 files indexed (ModTime match), got %d", stats.FilesIndexed)
+	}
+
+	// Assert: No chunks should be created
+	if stats.ChunksCreated != 0 {
+		t.Errorf("expected 0 chunks created, got %d", stats.ChunksCreated)
+	}
+
+	// Assert: No documents should be retrieved (skipped before GetDocument call)
+	if mockStore.getDocCalled {
+		t.Error("GetDocument should not be called for files with matching ModTime")
+	}
+
+	// Assert: No documents should be saved
+	if mockStore.saveDocCalled {
+		t.Error("SaveDocument should not be called for unchanged files")
+	}
+}
+
+// TestIndexAllWithProgress_ChangedFilesIndexed tests that files with different ModTimes are re-indexed
+func TestIndexAllWithProgress_ChangedFilesIndexed(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create test file
+	testFile := filepath.Join(tmpDir, "test.go")
+	content := "package main\n\nfunc main() {}"
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// Get current file ModTime
+	fileInfo, err := os.Stat(testFile)
+	if err != nil {
+		t.Fatalf("failed to get file info: %v", err)
+	}
+	currentModTime := time.Unix(fileInfo.ModTime().Unix(), 0)
+
+	// Create mock store with OLD ModTime (1 hour ago)
+	oldModTime := currentModTime.Add(-1 * time.Hour)
+	mockStore := newMockStore()
+	mockStore.documents["test.go"] = store.Document{
+		Path:     "test.go",
+		Hash:     "oldHash",
+		ModTime:  oldModTime,
+		ChunkIDs: []string{"oldChunk1"},
+	}
+
+	// Create indexer
+	mockEmbedder := newMockEmbedder()
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
+	if err != nil {
+		t.Fatalf("failed to create ignore matcher: %v", err)
+	}
+	scanner := NewScanner(tmpDir, ignoreMatcher)
+	chunker := NewChunker(512, 50)
+	indexer := NewIndexer(tmpDir, mockStore, mockEmbedder, chunker, scanner, time.Time{})
+
+	// Index with progress
+	stats, err := indexer.IndexAllWithProgress(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("IndexAllWithProgress failed: %v", err)
+	}
+
+	// Assert: File should be indexed (ModTime differs)
+	if stats.FilesIndexed != 1 {
+		t.Errorf("expected 1 file indexed (ModTime changed), got %d", stats.FilesIndexed)
+	}
+
+	// Assert: Chunks should be created
+	if stats.ChunksCreated == 0 {
+		t.Error("expected chunks to be created for changed file")
+	}
+
+	// Assert: Embedder should be called
+	if !mockEmbedder.embedCalled {
+		t.Error("EmbedBatch should be called for changed file")
+	}
+
+	// Assert: Document should be saved with new ModTime
+	if !mockStore.saveDocCalled {
+		t.Error("SaveDocument should be called for changed file")
+	}
+
+	savedDoc, ok := mockStore.documents["test.go"]
+	if !ok {
+		t.Error("document should exist in store")
+	} else {
+		expectedModTime := time.Unix(currentModTime.Unix(), 0)
+		if !savedDoc.ModTime.Equal(expectedModTime) {
+			t.Errorf("expected ModTime %v, got %v", expectedModTime, savedDoc.ModTime)
+		}
+	}
+}
+
+// TestIndexAllWithProgress_NewFilesIndexed tests that new files are indexed
+func TestIndexAllWithProgress_NewFilesIndexed(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create test file
+	testFile := filepath.Join(tmpDir, "newfile.go")
+	content := "package main\n\nfunc main() {}"
+	err := os.WriteFile(testFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// Create mock store WITHOUT the new file (empty store)
+	mockStore := newMockStore()
+
+	// Create indexer
+	mockEmbedder := newMockEmbedder()
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
+	if err != nil {
+		t.Fatalf("failed to create ignore matcher: %v", err)
+	}
+	scanner := NewScanner(tmpDir, ignoreMatcher)
+	chunker := NewChunker(512, 50)
+	indexer := NewIndexer(tmpDir, mockStore, mockEmbedder, chunker, scanner, time.Time{})
+
+	// Index with progress
+	stats, err := indexer.IndexAllWithProgress(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("IndexAllWithProgress failed: %v", err)
+	}
+
+	// Assert: New file should be indexed
+	if stats.FilesIndexed != 1 {
+		t.Errorf("expected 1 file indexed (new file), got %d", stats.FilesIndexed)
+	}
+
+	// Assert: Chunks should be created
+	if stats.ChunksCreated == 0 {
+		t.Error("expected chunks to be created for new file")
+	}
+
+	// Assert: Document should be saved
+	if !mockStore.saveDocCalled {
+		t.Error("SaveDocument should be called for new file")
+	}
+
+	// Verify the document exists
+	_, ok := mockStore.documents["newfile.go"]
+	if !ok {
+		t.Error("document should exist in store")
+	}
+}
+
+// TestIndexAllWithProgress_DeletedFilesRemoved tests that deleted files are removed from index
+func TestIndexAllWithProgress_DeletedFilesRemoved(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create only file A (file B is deleted)
+	fileA := filepath.Join(tmpDir, "fileA.go")
+	contentA := "package main\n\nfunc A() {}"
+	err := os.WriteFile(fileA, []byte(contentA), 0644)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// Create mock store with files A and B
+	mockStore := newMockStore()
+	mockStore.documents["fileA.go"] = store.Document{
+		Path:     "fileA.go",
+		Hash:     "hashA",
+		ModTime:  time.Now().Add(-1 * time.Hour),
+		ChunkIDs: []string{"chunkA"},
+	}
+	mockStore.documents["fileB.go"] = store.Document{
+		Path:     "fileB.go",
+		Hash:     "hashB",
+		ModTime:  time.Now().Add(-1 * time.Hour),
+		ChunkIDs: []string{"chunkB"},
+	}
+	// Add chunks so DeleteByFile can find them
+	mockStore.chunks["chunkA"] = store.Chunk{ID: "chunkA"}
+	mockStore.chunks["chunkB"] = store.Chunk{ID: "chunkB"}
+
+	// Create indexer
+	mockEmbedder := newMockEmbedder()
+	ignoreMatcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
+	if err != nil {
+		t.Fatalf("failed to create ignore matcher: %v", err)
+	}
+	scanner := NewScanner(tmpDir, ignoreMatcher)
+	chunker := NewChunker(512, 50)
+	indexer := NewIndexer(tmpDir, mockStore, mockEmbedder, chunker, scanner, time.Time{})
+
+	// Index with progress
+	stats, err := indexer.IndexAllWithProgress(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("IndexAllWithProgress failed: %v", err)
+	}
+
+	// Assert: One file should be removed (fileB)
+	if stats.FilesRemoved != 1 {
+		t.Errorf("expected 1 file removed (fileB deleted), got %d", stats.FilesRemoved)
+	}
+
+	// Assert: fileB should be deleted from store
+	if _, ok := mockStore.documents["fileB.go"]; ok {
+		t.Error("fileB.go should be deleted from store")
+	}
+
+	// Assert: fileB's chunks should be deleted
+	if _, ok := mockStore.chunks["chunkB"]; ok {
+		t.Error("chunkB should be deleted from store")
+	}
+
+	// Assert: fileA should still exist
+	if _, ok := mockStore.documents["fileA.go"]; !ok {
+		t.Error("fileA.go should still exist in store")
+	}
+}
+
+// TestTimeEqualBehavior verifies time.Equal handles precision correctly
+func TestTimeEqualBehavior(t *testing.T) {
+	tests := []struct {
+		name     string
+		t1       time.Time
+		t2       time.Time
+		expected bool
+	}{
+		{
+			name:     "Equal timestamps",
+			t1:       time.Unix(1640995200, 0),
+			t2:       time.Unix(1640995200, 0),
+			expected: true,
+		},
+		{
+			name:     "1 second difference",
+			t1:       time.Unix(1640995201, 0),
+			t2:       time.Unix(1640995200, 0),
+			expected: false,
+		},
+		{
+			name:     "Sub-second difference",
+			t1:       time.Unix(1640995200, 500000000),
+			t2:       time.Unix(1640995200, 0),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.t1.Equal(tt.t2)
+			if result != tt.expected {
+				t.Errorf("time.Equal(%v, %v) = %v, expected %v", tt.t1, tt.t2, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…_index_time added

## Description

When I run the grepai watch, indexing is automatic across the entire project.
Change in operation by:
- first watch, indexing entire project (as currently)
- saving the last indexing date in the config file (watcher.last_index_time)
- when a file is changed, reindexing the file (as currently)
- if more than 30 seconds have passed since the date was modified in the config, modify the date, otherwise do nothing, to avoid overloading the config writes
- when restarting watch, skip all files with no modification since last config date

## Related Issue
Fixes #

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

**Test Configuration:**
- OS: windows/wsl
- Go version: 1.25.6
- Embedding provider:

## Checklist

- [x] My code follows the project's code style
- [x] I have run `golangci-lint run` and fixed any issues
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed
- [x] I have added an entry to CHANGELOG.md (if applicable)
- [x] My changes generate no new warnings
- [x] All new and existing tests pass

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
