### PR TITLE
Add Nix flake for reproducible builds and development

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "grepai - AI-powered semantic code search tool";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      version = "0.18.0";
+
+      mkGrepai = pkgs: pkgs.buildGoModule {
+        pname = "grepai";
+        inherit version;
+        src = ./.;
+
+        vendorHash = "sha256-B3E/Faqe4CkrVDsOsvYo8cxpGUn7pwJrmI1pCMBaEJk=";
+
+        ldflags = [
+          "-s"
+          "-w"
+          "-X main.version=${version}"
+        ];
+
+        meta = with pkgs.lib; {
+          description = "AI-powered semantic code search tool";
+          homepage = "https://github.com/yoanbernabeu/grepai";
+          license = licenses.mit;
+          mainProgram = "grepai";
+        };
+      };
+    in
+    {
+      packages = forAllSystems (system: {
+        grepai = mkGrepai nixpkgs.legacyPackages.${system};
+        default = self.packages.${system}.grepai;
+      });
+
+      overlays.default = final: prev: {
+        grepai = mkGrepai final;
+      };
+
+      devShells = forAllSystems (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [ go gopls gotools go-tools ];
+            shellHook = ''
+              echo "grepai dev shell - Go $(go version | cut -d' ' -f3)"
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary

This PR adds a `flake.nix` to enable Nix users to easily build, run, and develop grepai.

## Why is this important?

- **Reproducible builds**: Nix flakes provide hermetic, reproducible builds across all platforms
- **Zero-dependency installation**: Users don't need to install Go or any build tools manually
- **Cross-platform support**: Works on Linux (x86_64, aarch64) and macOS (Intel, Apple Silicon)
- **Development environment**: Provides a ready-to-use dev shell with Go tooling
- **NixOS integration**: Includes an overlay for easy integration into NixOS configurations

## Usage

### Run directly (no installation)
```bash
nix run github:yoanbernabeu/grepai
```

### Install in user profile
```bash
nix profile install github:yoanbernabeu/grepai
```

### Development environment
```bash
nix develop github:yoanbernabeu/grepai
```

### Use in a NixOS/home-manager configuration
```nix
{
  inputs.grepai.url = "github:yoanbernabeu/grepai";

  # Then add the overlay
  nixpkgs.overlays = [ grepai.overlays.default ];

  # And install
  environment.systemPackages = [ pkgs.grepai ];
}
```