### PR TITLE
fix(config): resolve symlinks in FindProjectRoot

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -321,6 +321,12 @@ func FindProjectRoot() (string, error) {
 		return "", fmt.Errorf("failed to get current directory: %w", err)
 	}
 
+	// Resolve symlinks to handle symlinked directories
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
 	dir := cwd
 	for {
 		if Exists(dir) {


### PR DESCRIPTION
## Summary

- Add `filepath.EvalSymlinks()` in `FindProjectRoot()` to resolve symlinked directories
- Add unit test `TestFindProjectRootWithSymlink` to verify the fix
- Fixes issue where `grepai watch` indexed no files when run from a symlinked directory

Closes #83

## Test plan

- [x] Unit test added and passing (`make test`)
- [x] Linter passing (`make lint`)
- [x] Manual end-to-end test: created symlink, ran `grepai watch`, verified files indexed correctly
- [x] Search and trace commands work from symlinked directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)