### PR TITLE
feat(indexer): handle large chunks exceeding context limit

### DIFF
--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -244,6 +244,29 @@ chunking:
 - **Smaller chunks**: More precise matches, more results, faster
 - **More overlap**: Better continuity, larger index
 
+### Automatic Re-chunking
+
+If you configure a `chunking.size` larger than your embedder's context limit (e.g., 10000 tokens with a model that only supports 8192), grepai will automatically detect the error and re-chunk the content into smaller pieces.
+
+This happens transparently:
+1. grepai attempts to embed the chunk
+2. If the embedder returns a "context length exceeded" error, grepai splits the chunk in half
+3. The process repeats until chunks fit within the model's limit (up to 3 attempts)
+
+You'll see log messages like:
+```
+Re-chunking large_file.go chunk 0 (attempt 1/3): context limit exceeded
+Split chunk into 4 sub-chunks
+```
+
+**Recommended chunk sizes per model:**
+
+| Provider | Model | Max Context | Recommended Size |
+|----------|-------|-------------|------------------|
+| Ollama | nomic-embed-text | ~8192 | 512-2048 |
+| OpenAI | text-embedding-3-small | 8191 | 512-4096 |
+| LM Studio | nomic-embed-text-v1.5 | ~8192 | 512-2048 |
+
 ## Search Options
 
 grepai provides two optional search enhancements:

--- a/embedder/errors.go
+++ b/embedder/errors.go
@@ -1,0 +1,50 @@
+package embedder
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ContextLengthError indicates that the input text exceeds the model's context limit.
+// This error is retryable by re-chunking the input into smaller pieces.
+type ContextLengthError struct {
+	ChunkIndex      int    // Index of the chunk that exceeded the limit
+	EstimatedTokens int    // Estimated number of tokens in the chunk
+	MaxTokens       int    // Maximum tokens allowed by the model (if known)
+	Message         string // Original error message from the provider
+}
+
+func (e *ContextLengthError) Error() string {
+	if e.MaxTokens > 0 {
+		return fmt.Sprintf("chunk %d exceeds context limit: ~%d tokens (max %d): %s",
+			e.ChunkIndex, e.EstimatedTokens, e.MaxTokens, e.Message)
+	}
+	return fmt.Sprintf("chunk %d exceeds context limit: ~%d tokens: %s",
+		e.ChunkIndex, e.EstimatedTokens, e.Message)
+}
+
+// NewContextLengthError creates a new ContextLengthError.
+func NewContextLengthError(chunkIndex, estimatedTokens, maxTokens int, message string) *ContextLengthError {
+	return &ContextLengthError{
+		ChunkIndex:      chunkIndex,
+		EstimatedTokens: estimatedTokens,
+		MaxTokens:       maxTokens,
+		Message:         message,
+	}
+}
+
+// IsContextLengthError checks if an error is or wraps a ContextLengthError.
+func IsContextLengthError(err error) bool {
+	var ctxErr *ContextLengthError
+	return errors.As(err, &ctxErr)
+}
+
+// AsContextLengthError extracts a ContextLengthError from an error chain.
+// Returns nil if the error is not a ContextLengthError.
+func AsContextLengthError(err error) *ContextLengthError {
+	var ctxErr *ContextLengthError
+	if errors.As(err, &ctxErr) {
+		return ctxErr
+	}
+	return nil
+}

--- a/embedder/errors_test.go
+++ b/embedder/errors_test.go
@@ -1,0 +1,173 @@
+package embedder
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestContextLengthError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *ContextLengthError
+		contains []string
+	}{
+		{
+			name: "with max tokens",
+			err: &ContextLengthError{
+				ChunkIndex:      0,
+				EstimatedTokens: 10000,
+				MaxTokens:       8192,
+				Message:         "input exceeds context length",
+			},
+			contains: []string{"chunk 0", "~10000 tokens", "max 8192", "input exceeds context length"},
+		},
+		{
+			name: "without max tokens",
+			err: &ContextLengthError{
+				ChunkIndex:      2,
+				EstimatedTokens: 5000,
+				MaxTokens:       0,
+				Message:         "context limit exceeded",
+			},
+			contains: []string{"chunk 2", "~5000 tokens", "context limit exceeded"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			for _, substr := range tt.contains {
+				if !containsString(msg, substr) {
+					t.Errorf("error message %q should contain %q", msg, substr)
+				}
+			}
+		})
+	}
+}
+
+func TestNewContextLengthError(t *testing.T) {
+	err := NewContextLengthError(1, 9000, 8192, "too long")
+
+	if err.ChunkIndex != 1 {
+		t.Errorf("ChunkIndex = %d, expected 1", err.ChunkIndex)
+	}
+	if err.EstimatedTokens != 9000 {
+		t.Errorf("EstimatedTokens = %d, expected 9000", err.EstimatedTokens)
+	}
+	if err.MaxTokens != 8192 {
+		t.Errorf("MaxTokens = %d, expected 8192", err.MaxTokens)
+	}
+	if err.Message != "too long" {
+		t.Errorf("Message = %q, expected %q", err.Message, "too long")
+	}
+}
+
+func TestIsContextLengthError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "direct ContextLengthError",
+			err:      &ContextLengthError{Message: "test"},
+			expected: true,
+		},
+		{
+			name:     "wrapped ContextLengthError",
+			err:      fmt.Errorf("outer error: %w", &ContextLengthError{Message: "test"}),
+			expected: true,
+		},
+		{
+			name:     "double wrapped ContextLengthError",
+			err:      fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &ContextLengthError{Message: "test"})),
+			expected: true,
+		},
+		{
+			name:     "regular error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsContextLengthError(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsContextLengthError() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAsContextLengthError(t *testing.T) {
+	origErr := &ContextLengthError{ChunkIndex: 5, Message: "original"}
+
+	tests := []struct {
+		name          string
+		err           error
+		expectNil     bool
+		expectedIndex int
+	}{
+		{
+			name:          "direct error",
+			err:           origErr,
+			expectNil:     false,
+			expectedIndex: 5,
+		},
+		{
+			name:          "wrapped error",
+			err:           fmt.Errorf("wrapped: %w", origErr),
+			expectNil:     false,
+			expectedIndex: 5,
+		},
+		{
+			name:      "non-ContextLengthError",
+			err:       errors.New("other error"),
+			expectNil: true,
+		},
+		{
+			name:      "nil error",
+			err:       nil,
+			expectNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AsContextLengthError(tt.err)
+			if tt.expectNil {
+				if result != nil {
+					t.Error("expected nil, got non-nil")
+				}
+			} else {
+				if result == nil {
+					t.Fatal("expected non-nil, got nil")
+				}
+				if result.ChunkIndex != tt.expectedIndex {
+					t.Errorf("ChunkIndex = %d, expected %d", result.ChunkIndex, tt.expectedIndex)
+				}
+			}
+		})
+	}
+}
+
+// containsString is a helper to check if a string contains a substring
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes the issue where files cannot be indexed when chunks exceed the embedding model's context window limit (e.g., nomic-embed-text has ~8192 token limit).

**Problem reproduced:**
```
Failed to index large_file.go: failed to embed chunks: failed to embed text 0: 
Ollama returned status 500: {"error":"the input length exceeds the context length"}
```

## Proposed Solution

- Detect context limit errors from embedders (Ollama, OpenAI, LMStudio)
- Automatically re-chunk oversized chunks into smaller pieces
- Retry embedding with the smaller chunks
- Maintain backward compatibility with existing configs and embeddings

## Changes

🚧 **Work in Progress** 🚧

- [ ] Add context limit detection in embedders
- [ ] Implement automatic chunk splitting on error
- [ ] Add configuration validation/warnings
- [ ] Update tests
- [ ] Update documentation

## Test Plan

- [ ] Test with default config (should work as before)
- [ ] Test with large `chunking.size` config
- [ ] Test with existing index (backward compatibility)
- [ ] Unit tests for new functionality

## Related Issue

Closes #84

---
🤖 Generated with [Claude Code](https://claude.ai/code)