### PR TITLE
fix(embedder): only send dimensions param when explicitly configured

### DIFF
--- a/cli/init.go
+++ b/cli/init.go
@@ -18,7 +18,6 @@ var (
 )
 
 const (
-	openAI3SmallDimensions      = 1536
 	lmStudioEmbeddingDimensions = 768
 )
 
@@ -76,12 +75,13 @@ func runInit(cmd *cobra.Command, args []string) error {
 				cfg.Embedder.Provider = "lmstudio"
 				cfg.Embedder.Model = "text-embedding-nomic-embed-text-v1.5"
 				cfg.Embedder.Endpoint = "http://127.0.0.1:1234"
-				cfg.Embedder.Dimensions = lmStudioEmbeddingDimensions
+				dim := lmStudioEmbeddingDimensions
+				cfg.Embedder.Dimensions = &dim
 			case "3", "openai":
 				cfg.Embedder.Provider = "openai"
 				cfg.Embedder.Model = "text-embedding-3-small"
 				cfg.Embedder.Endpoint = "https://api.openai.com/v1"
-				cfg.Embedder.Dimensions = openAI3SmallDimensions
+				// OpenAI: leave Dimensions nil to use model's native dimensions
 			default:
 				cfg.Embedder.Provider = "ollama"
 			}
@@ -91,11 +91,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 			case "lmstudio":
 				cfg.Embedder.Model = "text-embedding-nomic-embed-text-v1.5"
 				cfg.Embedder.Endpoint = "http://127.0.0.1:1234"
-				cfg.Embedder.Dimensions = lmStudioEmbeddingDimensions
+				dim := lmStudioEmbeddingDimensions
+				cfg.Embedder.Dimensions = &dim
 			case "openai":
 				cfg.Embedder.Model = "text-embedding-3-small"
 				cfg.Embedder.Endpoint = "https://api.openai.com/v1"
-				cfg.Embedder.Dimensions = openAI3SmallDimensions
+				// OpenAI: leave Dimensions nil to use model's native dimensions
 			}
 		}
 

--- a/cli/status.go
+++ b/cli/status.go
@@ -324,7 +324,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		st = gobStore
 	case "postgres":
 		var err error
-		st, err = store.NewPostgresStore(ctx, cfg.Store.Postgres.DSN, projectRoot, cfg.Embedder.Dimensions)
+		st, err = store.NewPostgresStore(ctx, cfg.Store.Postgres.DSN, projectRoot, cfg.Embedder.GetDimensions())
 		if err != nil {
 			return fmt.Errorf("failed to connect to postgres: %w", err)
 		}
@@ -334,7 +334,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			collectionName = store.SanitizeCollectionName(projectRoot)
 		}
 		var err error
-		st, err = store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.Dimensions)
+		st, err = store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.GetDimensions())
 		if err != nil {
 			return fmt.Errorf("failed to connect to qdrant: %w", err)
 		}

--- a/cli/workspace.go
+++ b/cli/workspace.go
@@ -145,8 +145,8 @@ func runWorkspaceShow(cmd *cobra.Command, args []string) error {
 	if ws.Embedder.Endpoint != "" {
 		fmt.Printf("  Endpoint: %s\n", ws.Embedder.Endpoint)
 	}
-	if ws.Embedder.Dimensions > 0 {
-		fmt.Printf("  Dimensions: %d\n", ws.Embedder.Dimensions)
+	if ws.Embedder.Dimensions != nil {
+		fmt.Printf("  Dimensions: %d\n", *ws.Embedder.Dimensions)
 	}
 
 	fmt.Printf("\nProjects (%d):\n", len(ws.Projects))
@@ -300,7 +300,8 @@ func runWorkspaceCreate(cmd *cobra.Command, args []string) error {
 			model = "nomic-embed-text"
 		}
 		embedderConfig.Model = model
-		embedderConfig.Dimensions = 768
+		dim := 768
+		embedderConfig.Dimensions = &dim
 	case "2":
 		embedderConfig.Provider = "openai"
 		fmt.Print("OpenAI API Key: ")
@@ -314,7 +315,7 @@ func runWorkspaceCreate(cmd *cobra.Command, args []string) error {
 		}
 		embedderConfig.Model = model
 		embedderConfig.Endpoint = "https://api.openai.com/v1"
-		embedderConfig.Dimensions = 1536
+		// OpenAI: leave Dimensions nil to use model's native dimensions
 	case "3":
 		embedderConfig.Provider = "lmstudio"
 		fmt.Print("LM Studio endpoint [http://127.0.0.1:1234]: ")
@@ -331,7 +332,8 @@ func runWorkspaceCreate(cmd *cobra.Command, args []string) error {
 			model = "nomic-embed-text"
 		}
 		embedderConfig.Model = model
-		embedderConfig.Dimensions = 768
+		dim := 768
+		embedderConfig.Dimensions = &dim
 	default:
 		return fmt.Errorf("invalid choice: %s", embedderChoice)
 	}

--- a/config/workspace_test.go
+++ b/config/workspace_test.go
@@ -7,6 +7,11 @@ import (
 	"testing"
 )
 
+// intPtr is a helper function for creating *int values in tests.
+func intPtr(v int) *int {
+	return &v
+}
+
 // setTestHomeDir sets the home directory for testing in a cross-platform way.
 // On Windows, os.UserHomeDir() uses USERPROFILE, not HOME.
 func setTestHomeDir(t *testing.T, dir string) func() {
@@ -65,7 +70,7 @@ func TestWorkspaceConfigOperations(t *testing.T) {
 				Provider:   "ollama",
 				Model:      "nomic-embed-text",
 				Endpoint:   "http://localhost:11434",
-				Dimensions: 768,
+				Dimensions: intPtr(768),
 			},
 			Projects: []ProjectEntry{},
 		}
@@ -235,7 +240,7 @@ func TestWorkspaceConfigOperations(t *testing.T) {
 				Provider:   "ollama",
 				Model:      "nomic-embed-text",
 				Endpoint:   "http://localhost:11434",
-				Dimensions: 768,
+				Dimensions: intPtr(768),
 			},
 			Projects: []ProjectEntry{
 				{Name: "project1", Path: "/path/1"},

--- a/embedder/embedder_test.go
+++ b/embedder/embedder_test.go
@@ -157,8 +157,9 @@ func TestNewOpenAIEmbedder_Defaults(t *testing.T) {
 		t.Errorf("expected model %s, got %s", defaultOpenAIModel, e.model)
 	}
 
-	if e.dimensions != defaultOpenAI3SmallDimensions {
-		t.Errorf("expected dimensions %d, got %d", defaultOpenAI3SmallDimensions, e.dimensions)
+	// dimensions should be nil by default (no dimensions param sent to API)
+	if e.dimensions != nil {
+		t.Errorf("expected nil dimensions, got %v", e.dimensions)
 	}
 }
 
@@ -190,8 +191,8 @@ func TestNewOpenAIEmbedder_WithOptions(t *testing.T) {
 		t.Errorf("expected apiKey %s, got %s", customKey, e.apiKey)
 	}
 
-	if e.dimensions != customDimensions {
-		t.Errorf("expected dimensions %d, got %d", customDimensions, e.dimensions)
+	if e.dimensions == nil || *e.dimensions != customDimensions {
+		t.Errorf("expected dimensions %d, got %v", customDimensions, e.dimensions)
 	}
 }
 

--- a/embedder/openai.go
+++ b/embedder/openai.go
@@ -26,7 +26,7 @@ type OpenAIEmbedder struct {
 	endpoint    string
 	model       string
 	apiKey      string
-	dimensions  int
+	dimensions  *int
 	parallelism int
 	retryPolicy RetryPolicy
 	client      *http.Client
@@ -38,7 +38,7 @@ type OpenAIEmbedder struct {
 type openAIEmbedRequest struct {
 	Model      string   `json:"model"`
 	Input      []string `json:"input"`
-	Dimensions int      `json:"dimensions,omitempty"`
+	Dimensions *int     `json:"dimensions,omitempty"`
 }
 
 type openAIEmbedResponse struct {
@@ -80,7 +80,7 @@ func WithOpenAIKey(key string) OpenAIOption {
 }
 func WithOpenAIDimensions(dimensions int) OpenAIOption {
 	return func(e *OpenAIEmbedder) {
-		e.dimensions = dimensions
+		e.dimensions = &dimensions
 	}
 }
 
@@ -113,7 +113,7 @@ func NewOpenAIEmbedder(opts ...OpenAIOption) (*OpenAIEmbedder, error) {
 	e := &OpenAIEmbedder{
 		endpoint:    defaultOpenAIEndpoint,
 		model:       defaultOpenAIModel,
-		dimensions:  defaultOpenAI3SmallDimensions,
+		dimensions:  nil, // nil = let the model use its native dimensions
 		parallelism: defaultParallelism,
 		retryPolicy: DefaultRetryPolicy(),
 		client: &http.Client{
@@ -215,7 +215,10 @@ func (e *OpenAIEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]fl
 }
 
 func (e *OpenAIEmbedder) Dimensions() int {
-	return e.dimensions
+	if e.dimensions == nil {
+		return defaultOpenAI3SmallDimensions
+	}
+	return *e.dimensions
 }
 
 func (e *OpenAIEmbedder) Close() error {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -30,7 +30,7 @@ func TestServerCreateEmbedder_AppliesConfiguredDimensions(t *testing.T) {
 			s := &Server{}
 			cfg := config.DefaultConfig()
 			cfg.Embedder.Provider = tt.provider
-			cfg.Embedder.Dimensions = tt.dimensions
+			cfg.Embedder.Dimensions = &tt.dimensions
 			cfg.Embedder.APIKey = tt.apiKey
 
 			emb, err := s.createEmbedder(cfg)


### PR DESCRIPTION
## Summary

- Change `EmbedderConfig.Dimensions` from `int` to `*int` to distinguish between omitted and explicit values
- When `Dimensions` is `nil`, the `dimensions` parameter is NOT sent to the OpenAI API, allowing the model to use its native dimensions
- Add `GetDimensions()` helper method for cases where a concrete int value is needed (e.g., vector store initialization)
- Update all embedder creation sites to conditionally pass the dimensions option only when explicitly configured

## Problem

The `dimensions` parameter was always sent to the OpenAI embeddings API, even when omitted from the config. This caused issues with some OpenAI-compatible endpoints that don't support the `dimensions` parameter.

## Solution

Use a pointer `*int` for the dimensions field:
- `nil` → parameter is omitted from API requests (using `omitempty`)
- non-nil → explicit value is sent

For providers like Ollama/LMStudio, a default is still applied (768) since they need it for internal state. For OpenAI, the default is intentionally left `nil`.

## Test plan

- [x] All existing tests pass
- [x] Linting passes
- [x] Build successful
- [x] Added unit tests for nil/non-nil dimension behavior
- [x] Added unit tests for JSON serialization (omitempty works correctly)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)