### PR TITLE
fix: add progress reporting for sequential (Ollama) indexing

### DIFF
--- a/cli/watch.go
+++ b/cli/watch.go
@@ -683,14 +683,15 @@ func printProgress(current, total int, filePath string) {
 
 func printBatchProgress(info indexer.BatchProgressInfo) {
 	if info.Retrying {
-		// Clear current line and show retry message with rate limit visibility
 		fmt.Printf("\r%s\r", strings.Repeat(" ", 80))
 		reason := describeRetryReason(info.StatusCode)
 		fmt.Printf("%s - Retrying batch %d (attempt %d/5)...\n", reason, info.BatchIndex+1, info.Attempt)
 	} else if info.TotalChunks > 0 {
-		// Show progress percentage after batch completion
 		percentage := float64(info.CompletedChunks) / float64(info.TotalChunks) * 100
-		fmt.Printf("\rEmbedding progress: %d/%d chunks (%.0f%%)...", info.CompletedChunks, info.TotalChunks, percentage)
+		barWidth := 20
+		filled := int(float64(barWidth) * float64(info.CompletedChunks) / float64(info.TotalChunks))
+		bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
+		fmt.Printf("\rEmbedding [%s] %3.0f%% (%d/%d)", bar, percentage, info.CompletedChunks, info.TotalChunks)
 	}
 }
 


### PR DESCRIPTION
## Summary

When using Ollama as the embedding provider, users experience a confusing UX where:
1. The scan progress bar completes quickly (5 seconds)
2. Then nothing appears to happen for 30+ minutes during embedding
3. Users cancel, thinking grepai is broken

This PR fixes the issue by adding progress reporting to the sequential indexing path used by Ollama.

## Changes

- **indexer/indexer.go**: Added `BatchProgressInfo` callbacks to the sequential indexing loop
- **cli/watch.go**: Updated `printBatchProgress()` to show a visual progress bar matching the scan bar style

## Before

```
Indexing [████████████████████] 100% (310/310) ...file.cs
Embedding progress: 0/310 chunks (0%)...
```
(Then appears to hang with no updates)

## After

```
Indexing  [████████████████████] 100% (310/310) ...file.cs
Embedding [█░░░░░░░░░░░░░░░░░░░]   7% (21/310)
```
(Progress bar updates in real-time during embedding)

## Testing

Tested with a 310-file .NET codebase using `grepai init --provider ollama --backend gob` followed by `grepai watch`. Both progress bars now display correctly and update in real-time.

Fixes #87

---

## Disclosure

This PR was **AI-driven**. The diagnosis, code changes, and testing were performed by Claude (Anthropic's LLM) via Claude Code. I (the account submitting this PR) am not proficient in Go — please review the changes carefully. Happy to address any feedback or requested changes.
