### PR TITLE
feat(cli): add TOON format support for search and trace commands

### DIFF
--- a/cli/search_test.go
+++ b/cli/search_test.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/alpkeskin/gotoon"
 	"github.com/yoanbernabeu/grepai/store"
 )
 
@@ -116,31 +118,34 @@ func TestOutputSearchCompactJSON(t *testing.T) {
 	}
 }
 
-func TestCompactFlagRequiresJSON(t *testing.T) {
-	// Test that runSearch returns error when --compact is used without --json
+func TestCompactFlagRequiresJSONOrTOON(t *testing.T) {
+	// Test that runSearch returns error when --compact is used without --json or --toon
 	// We test this by directly checking the validation logic
 
 	// Save original values
 	originalCompact := searchCompact
 	originalJSON := searchJSON
+	originalTOON := searchTOON
 
 	// Reset after test
 	defer func() {
 		searchCompact = originalCompact
 		searchJSON = originalJSON
+		searchTOON = originalTOON
 	}()
 
-	// Set up test case: --compact without --json
+	// Set up test case: --compact without --json and --toon
 	searchCompact = true
 	searchJSON = false
+	searchTOON = false
 
 	// The validation happens at the start of runSearch
-	if searchCompact && !searchJSON {
+	if searchCompact && !searchJSON && !searchTOON {
 		// This is the expected behavior - validation would fail
 		return
 	}
 
-	t.Error("expected --compact to require --json flag")
+	t.Error("expected --compact to require --json or --toon flag")
 }
 
 func TestCompactFlagWithJSON(t *testing.T) {
@@ -149,20 +154,49 @@ func TestCompactFlagWithJSON(t *testing.T) {
 	// Save original values
 	originalCompact := searchCompact
 	originalJSON := searchJSON
+	originalTOON := searchTOON
 
 	// Reset after test
 	defer func() {
 		searchCompact = originalCompact
 		searchJSON = originalJSON
+		searchTOON = originalTOON
 	}()
 
 	// Set up test case: --compact with --json
 	searchCompact = true
 	searchJSON = true
+	searchTOON = false
 
 	// The validation should pass
-	if searchCompact && !searchJSON {
+	if searchCompact && !searchJSON && !searchTOON {
 		t.Error("expected --compact with --json to be valid")
+	}
+}
+
+func TestCompactFlagWithTOON(t *testing.T) {
+	// Test that --compact with --toon is valid
+
+	// Save original values
+	originalCompact := searchCompact
+	originalJSON := searchJSON
+	originalTOON := searchTOON
+
+	// Reset after test
+	defer func() {
+		searchCompact = originalCompact
+		searchJSON = originalJSON
+		searchTOON = originalTOON
+	}()
+
+	// Set up test case: --compact with --toon
+	searchCompact = true
+	searchJSON = false
+	searchTOON = true
+
+	// The validation should pass
+	if searchCompact && !searchJSON && !searchTOON {
+		t.Error("expected --compact with --toon to be valid")
 	}
 }
 
@@ -222,5 +256,148 @@ func TestSearchResultCompactJSONStruct(t *testing.T) {
 
 	if _, exists := decoded["content"]; exists {
 		t.Error("expected 'content' field to be absent in compact struct")
+	}
+}
+
+func TestOutputSearchTOON(t *testing.T) {
+	results := []store.SearchResult{
+		{
+			Chunk: store.Chunk{
+				FilePath:  "test/file.go",
+				StartLine: 10,
+				EndLine:   20,
+				Content:   "func TestFunction() {}",
+			},
+			Score: 0.95,
+		},
+	}
+
+	// Encode using gotoon
+	toonResults := make([]SearchResultJSON, len(results))
+	for i, r := range results {
+		toonResults[i] = SearchResultJSON{
+			FilePath:  r.Chunk.FilePath,
+			StartLine: r.Chunk.StartLine,
+			EndLine:   r.Chunk.EndLine,
+			Score:     r.Score,
+			Content:   r.Chunk.Content,
+		}
+	}
+
+	output, err := gotoon.Encode(toonResults)
+	if err != nil {
+		t.Fatalf("failed to encode TOON: %v", err)
+	}
+
+	// Verify output is not empty and is valid TOON
+	if output == "" {
+		t.Error("expected TOON output to be non-empty")
+	}
+
+	// TOON format should contain the file path
+	if !strings.Contains(output, "test/file.go") {
+		t.Error("expected TOON output to contain file path")
+	}
+
+	// TOON format should contain content
+	if !strings.Contains(output, "TestFunction") {
+		t.Error("expected TOON output to contain content")
+	}
+}
+
+func TestOutputSearchCompactTOON(t *testing.T) {
+	results := []store.SearchResult{
+		{
+			Chunk: store.Chunk{
+				FilePath:  "test/file.go",
+				StartLine: 10,
+				EndLine:   20,
+				Content:   "func TestFunction() {}",
+			},
+			Score: 0.95,
+		},
+	}
+
+	// Encode using gotoon with compact struct
+	toonResults := make([]SearchResultCompactJSON, len(results))
+	for i, r := range results {
+		toonResults[i] = SearchResultCompactJSON{
+			FilePath:  r.Chunk.FilePath,
+			StartLine: r.Chunk.StartLine,
+			EndLine:   r.Chunk.EndLine,
+			Score:     r.Score,
+		}
+	}
+
+	output, err := gotoon.Encode(toonResults)
+	if err != nil {
+		t.Fatalf("failed to encode TOON: %v", err)
+	}
+
+	// Verify output is not empty
+	if output == "" {
+		t.Error("expected TOON output to be non-empty")
+	}
+
+	// TOON format should contain the file path
+	if !strings.Contains(output, "test/file.go") {
+		t.Error("expected TOON output to contain file path")
+	}
+}
+
+func TestTOONSmallerThanJSON(t *testing.T) {
+	results := []store.SearchResult{
+		{
+			Chunk: store.Chunk{
+				FilePath:  "test/file.go",
+				StartLine: 10,
+				EndLine:   20,
+				Content:   "func TestFunction() {\n\treturn nil\n}",
+			},
+			Score: 0.95,
+		},
+		{
+			Chunk: store.Chunk{
+				FilePath:  "test/file2.go",
+				StartLine: 30,
+				EndLine:   40,
+				Content:   "func AnotherFunction() {\n\treturn true\n}",
+			},
+			Score: 0.85,
+		},
+	}
+
+	// Convert to JSON structs
+	jsonResults := make([]SearchResultJSON, len(results))
+	for i, r := range results {
+		jsonResults[i] = SearchResultJSON{
+			FilePath:  r.Chunk.FilePath,
+			StartLine: r.Chunk.StartLine,
+			EndLine:   r.Chunk.EndLine,
+			Score:     r.Score,
+			Content:   r.Chunk.Content,
+		}
+	}
+
+	// Encode as JSON
+	var jsonBuf bytes.Buffer
+	encoder := json.NewEncoder(&jsonBuf)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(jsonResults); err != nil {
+		t.Fatalf("failed to encode JSON: %v", err)
+	}
+
+	// Encode as TOON
+	toonOutput, err := gotoon.Encode(jsonResults)
+	if err != nil {
+		t.Fatalf("failed to encode TOON: %v", err)
+	}
+
+	jsonSize := len(jsonBuf.Bytes())
+	toonSize := len(toonOutput)
+
+	// TOON should be smaller than JSON
+	if toonSize >= jsonSize {
+		t.Errorf("expected TOON (%d bytes) to be smaller than JSON (%d bytes)", toonSize, jsonSize)
 	}
 }

--- a/docs/src/content/docs/search-guide.md
+++ b/docs/src/content/docs/search-guide.md
@@ -71,16 +71,21 @@ func AuthMiddleware() gin.HandlerFunc {
 - **File:lines**: Location of the matching chunk
 - **Content**: Code snippet with context
 
-### JSON Output
+### Structured Output
 
-For AI agents and scripts, use the `--json` flag:
+For AI agents and scripts, use `--json` or `--toon` flags:
 
 ```bash
+# JSON output
 grepai search "authentication" --json           # Full JSON output
 grepai search "authentication" --json --compact # Minimal JSON (no content field)
+
+# TOON output (~50% fewer tokens than JSON)
+grepai search "authentication" --toon           # Full TOON output
+grepai search "authentication" --toon --compact # Minimal TOON (no content field)
 ```
 
-Output format:
+#### JSON Format
 
 ```json
 [
@@ -93,6 +98,24 @@ Output format:
   }
 ]
 ```
+
+#### TOON Format
+
+TOON (Token-Oriented Object Notation) is a more compact format designed for AI agents:
+
+```
+[{file_path:middleware/auth.go,start_line:15,end_line:45,score:0.89,content:func AuthMiddleware() gin.HandlerFunc { ... }}]
+```
+
+**When to use TOON:**
+- AI agents with token constraints
+- High-volume search operations
+- When bandwidth or cost is a concern
+
+**When to use JSON:**
+- Human-readable output needed
+- Integration with existing JSON tooling
+- Debugging and inspection
 
 ### Search Enhancements
 
@@ -148,8 +171,11 @@ grepai search "REST API route handlers"
 Provide code context to AI agents:
 
 ```bash
-# Get compact JSON for AI processing (~80% fewer tokens)
+# JSON output (~80% fewer tokens with --compact)
 grepai search "payment processing" --json --compact --limit 5
+
+# TOON output (even more compact, ~50% fewer tokens than JSON)
+grepai search "payment processing" --toon --compact --limit 5
 ```
 
 ### Commands Reference

--- a/docs/src/content/docs/subagent.md
+++ b/docs/src/content/docs/subagent.md
@@ -76,13 +76,15 @@ You are a specialized code exploration agent with access to grepai.
 ### Primary Tools
 
 Use `grepai search` for semantic code search:
-- grepai search "authentication flow"
-- grepai search "error handling"
+- grepai search "authentication flow" --json
+- grepai search "error handling" --toon --compact
 
 Use `grepai trace` for call graph analysis:
-- grepai trace callers "Login"
-- grepai trace callees "HandleRequest"
-- grepai trace graph "ProcessOrder" --depth 3
+- grepai trace callers "Login" --json
+- grepai trace callees "HandleRequest" --toon
+- grepai trace graph "ProcessOrder" --depth 3 --toon
+
+**Note:** Use `--toon` for ~50% fewer tokens than `--json`.
 
 ### Workflow
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/yoanbernabeu/grepai
 go 1.24.2
 
 require (
+	github.com/alpkeskin/gotoon v0.1.1
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fsnotify/fsnotify v1.9.0
@@ -14,6 +15,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sync v0.18.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -49,7 +51,6 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251111163417-95abcf5c77ba // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 entgo.io/ent v0.14.3 h1:wokAV/kIlH9TeklJWGGS7AYJdVckr0DloWjIcO9iIIQ=
 entgo.io/ent v0.14.3/go.mod h1:aDPE/OziPEu8+OWbzy4UlvWmD2/kbRuWfK2A40hcxJM=
+github.com/alpkeskin/gotoon v0.1.1 h1:GQOVwMfWKINnfEA6slrXHJaJYDwnUFmrPlXOtnuja1w=
+github.com/alpkeskin/gotoon v0.1.1/go.mod h1:XRTz8RM4tz8M2nB37MNRN8rHF4YgeYd8nIXmoU0B0+M=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=


### PR DESCRIPTION
## Summary

- Add `--toon`/`-t` flag to `search` and `trace` commands for TOON output format
- Add `format` parameter ("json"/"toon") to all MCP tools
- TOON format uses ~50% fewer tokens than JSON in compact mode
- Flags `--json` and `--toon` are mutually exclusive
- `--compact` now works with both `--json` and `--toon`

Closes #63

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] CLI tests: `--json`, `--toon`, `--compact` combinations
- [x] MCP tests: `format: "json"` and `format: "toon"` on all tools
- [x] Validation: `--json --toon` fails, `--compact` alone fails
- [x] Retrocompatibility: existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)