### PR TITLE
feat(store): content-addressed embedding deduplication

### DIFF
--- a/store/gob.go
+++ b/store/gob.go
@@ -258,6 +258,22 @@ func (s *GOBStore) GetAllChunks(ctx context.Context) ([]Chunk, error) {
 	return chunks, nil
 }
 
+// LookupByContentHash searches in-memory chunks for a matching content hash.
+func (s *GOBStore) LookupByContentHash(ctx context.Context, contentHash string) ([]float32, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, chunk := range s.chunks {
+		if chunk.ContentHash == contentHash && len(chunk.Vector) > 0 {
+			vec := make([]float32, len(chunk.Vector))
+			copy(vec, chunk.Vector)
+			return vec, true, nil
+		}
+	}
+
+	return nil, false, nil
+}
+
 // cosineSimilarity calculates the cosine similarity between two vectors
 func cosineSimilarity(a, b []float32) float32 {
 	if len(a) != len(b) {


### PR DESCRIPTION
## Summary

Split from #109 (1/4). Adds content-addressed embedding deduplication to avoid redundant embedder API calls for identical content across worktrees.

- Add `ContentHash` field (SHA256) to `store.Chunk` and `EmbeddingCache` interface
- Implement `LookupByContentHash` for GOB, Postgres, and Qdrant stores
- Integrate cache lookup in indexer before calling embedder
- **Bug fix**: Add `CreateFieldIndex` for `content_hash` in Qdrant `ensureCollection` (was causing sequential scan)
- Postgres: add partial index `idx_chunks_content_hash` for efficient lookups

## Test plan

- [x] `go build ./...` passes (linux, windows, darwin)
- [x] `go vet ./...` clean
- [x] `go test ./store/... ./indexer/...` all pass with `-race`
- [x] New test: `TestGOBStore_LookupByContentHash`

Part of #109 split. See also: PR 2 (GOB locking), PR 3 (worktree detection), PR 4 (multi-worktree watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)