### PR TITLE
feat(nix): automate flake.nix update in release workflow

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -85,10 +85,26 @@ Update version in `docs/src/components/homepage/HeroAnimated.astro` line 6:
 const { version = "X.Y.Z" } = Astro.props;
 ```
 
+#### 4.3 Nix Flake
+
+Update `flake.nix`:
+
+1. Update `version` (line 13):
+
+```nix
+version = "X.Y.Z";
+```
+
+2. Update `vendorHash`:
+   - Set `vendorHash = "";` temporarily in `flake.nix`
+   - Run `make nix-hash` to compute the correct hash (requires Docker)
+   - Replace with the new hash: `vendorHash = "sha256-XXXXX";`
+   - If Docker is not available, ask the user to provide the hash or skip this step
+
 ### Step 5: Commit and Push
 
 ```bash
-git add CHANGELOG.md docs/src/components/homepage/HeroAnimated.astro
+git add CHANGELOG.md docs/src/components/homepage/HeroAnimated.astro flake.nix
 git commit -m "chore(release): bump version to X.Y.Z
 
 Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
@@ -130,6 +146,7 @@ GitHub `--generate-notes` automatically credits contributors in release notes.
 - [ ] CHANGELOG.md updated with all PRs
 - [ ] All contributors credited with @username
 - [ ] Hero version updated in docs
+- [ ] Nix flake version and vendorHash updated in flake.nix
 - [ ] CI passed after version commit
 - [ ] GitHub release created
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test clean lint run docs docs-generate docs-build docs-dev fmt pre-commit
+.PHONY: build install test clean lint run docs docs-generate docs-build docs-dev fmt pre-commit nix-hash
 
 BINARY_NAME=grepai
 VERSION?=0.1.0
@@ -67,3 +67,10 @@ pre-commit: fmt
 	docker run --rm -v $(PWD):/app -w /app golangci/golangci-lint:v1.64.2 golangci-lint run ./...
 	go test -race ./...
 	@echo "✓ All checks passed! Ready to commit."
+
+# Nix flake: compute vendorHash via Docker
+nix-hash:
+	@echo "Computing vendorHash (requires Docker)..."
+	@docker run --rm -v $(PWD):/src -w /src nixos/nix:latest sh -c \
+		'echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf && \
+		nix build .#grepai 2>&1 | grep "got:" | sed "s/.*got:\s*//"'

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770197578,
+        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-      version = "0.18.0";
+      version = "0.27.0";
 
       mkGrepai = pkgs: pkgs.buildGoModule {
         pname = "grepai";


### PR DESCRIPTION
## Summary

- Add `make nix-hash` Makefile target to compute Nix `vendorHash` via Docker
- Integrate `flake.nix` update (version + vendorHash) into the release skill workflow (section 4.3)
- Fix `flake.nix` version from `0.18.0` to `0.27.0` to match the current release

Closes #67

## Test plan

- [ ] Run `make nix-hash` with Docker running — should output the correct `sha256-...` hash
- [ ] Review `SKILL.md` section 4.3 for clarity and completeness
- [ ] Verify `flake.nix` version matches current release (0.27.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)