### PR TITLE
feat(stats): add token savings monitoring system (`grepai stats`)

### DIFF
--- a/cli/search.go
+++ b/cli/search.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/alpkeskin/gotoon"
 	"github.com/spf13/cobra"
@@ -13,6 +15,7 @@ import (
 	"github.com/yoanbernabeu/grepai/embedder"
 	"github.com/yoanbernabeu/grepai/rpg"
 	"github.com/yoanbernabeu/grepai/search"
+	"github.com/yoanbernabeu/grepai/stats"
 	"github.com/yoanbernabeu/grepai/store"
 )
 
@@ -208,57 +211,107 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 	// JSON output mode
 	if searchJSON {
+		var err error
+		var outputStr string
 		if searchCompact {
-			return outputSearchCompactJSON(results, enrichments)
+			outputStr, err = captureSearchCompactJSON(results, enrichments)
+		} else {
+			outputStr, err = captureSearchJSON(results, enrichments)
 		}
-		return outputSearchJSON(results, enrichments)
+		if err != nil {
+			return err
+		}
+		fmt.Print(outputStr)
+		recordSearchStats(projectRoot, stats.Search, outputModeFromFlags(searchJSON, searchTOON, searchCompact), len(results), outputStr)
+		return nil
 	}
 
 	// TOON output mode
 	if searchTOON {
+		var err error
+		var outputStr string
 		if searchCompact {
-			return outputSearchCompactTOON(results, enrichments)
+			outputStr, err = captureSearchCompactTOON(results, enrichments)
+		} else {
+			outputStr, err = captureSearchTOON(results, enrichments)
 		}
-		return outputSearchTOON(results, enrichments)
+		if err != nil {
+			return err
+		}
+		fmt.Print(outputStr)
+		recordSearchStats(projectRoot, stats.Search, outputModeFromFlags(searchJSON, searchTOON, searchCompact), len(results), outputStr)
+		return nil
 	}
 
 	if len(results) == 0 {
 		fmt.Println("No results found.")
+		recordSearchStats(projectRoot, stats.Search, stats.Full, 0, "")
 		return nil
 	}
 
-	// Display results
-	fmt.Printf("Found %d results for: %q\n\n", len(results), query)
+	// Display results (plain text — build output string for token estimation)
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "Found %d results for: %q\n\n", len(results), query)
 
 	for i, result := range results {
-		fmt.Printf("─── Result %d (score: %.4f) ───\n", i+1, result.Score)
-		fmt.Printf("File: %s:%d-%d\n", result.Chunk.FilePath, result.Chunk.StartLine, result.Chunk.EndLine)
-		fmt.Println()
+		fmt.Fprintf(&buf, "─── Result %d (score: %.4f) ───\n", i+1, result.Score)
+		fmt.Fprintf(&buf, "File: %s:%d-%d\n", result.Chunk.FilePath, result.Chunk.StartLine, result.Chunk.EndLine)
+		buf.WriteString("\n")
 
-		// Display content with line numbers
 		lines := strings.Split(result.Chunk.Content, "\n")
-		// Skip the "File: xxx" prefix line if present
 		startIdx := 0
 		if len(lines) > 0 && strings.HasPrefix(lines[0], "File: ") {
-			startIdx = 2 // Skip "File: xxx" and empty line
+			startIdx = 2
 		}
 
 		lineNum := result.Chunk.StartLine
 		for j := startIdx; j < len(lines) && j < startIdx+15; j++ {
-			fmt.Printf("%4d │ %s\n", lineNum, lines[j])
+			fmt.Fprintf(&buf, "%4d │ %s\n", lineNum, lines[j])
 			lineNum++
 		}
 		if len(lines)-startIdx > 15 {
-			fmt.Printf("     │ ... (%d more lines)\n", len(lines)-startIdx-15)
+			fmt.Fprintf(&buf, "     │ ... (%d more lines)\n", len(lines)-startIdx-15)
 		}
-		fmt.Println()
+		buf.WriteString("\n")
 	}
 
+	outputStr := buf.String()
+	fmt.Print(outputStr)
+	recordSearchStats(projectRoot, stats.Search, stats.Full, len(results), outputStr)
 	return nil
 }
 
-// outputSearchJSON outputs results in JSON format for AI agents
-func outputSearchJSON(results []store.SearchResult, enrichments []rpgEnrichment) error {
+// outputModeFromFlags determines the OutputMode from the active CLI flags.
+func outputModeFromFlags(jsonFlag, toonFlag, compactFlag bool) stats.OutputMode {
+	if compactFlag {
+		return stats.Compact
+	}
+	if toonFlag {
+		return stats.Toon
+	}
+	return stats.Full
+}
+
+// recordSearchStats fires a goroutine to record a stats entry without blocking.
+func recordSearchStats(projectRoot, commandType, outputMode string, resultCount int, outputStr string) {
+	rec := stats.NewRecorder(projectRoot)
+	entry := stats.Entry{
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		CommandType:  commandType,
+		OutputMode:   outputMode,
+		ResultCount:  resultCount,
+		OutputTokens: embedder.EstimateTokens(outputStr),
+		GrepTokens:   stats.GrepEquivalentTokens(resultCount),
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_ = rec.Record(ctx, entry)
+	}()
+}
+
+// captureSearchJSON returns JSON-encoded results as a string.
+func captureSearchJSON(results []store.SearchResult, enrichments []rpgEnrichment) (string, error) {
 	jsonResults := make([]SearchResultJSON, len(results))
 	for i, r := range results {
 		jsonResults[i] = SearchResultJSON{
@@ -271,14 +324,17 @@ func outputSearchJSON(results []store.SearchResult, enrichments []rpgEnrichment)
 			SymbolName:  enrichments[i].SymbolName,
 		}
 	}
-
-	encoder := json.NewEncoder(os.Stdout)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(jsonResults)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(jsonResults); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
-// outputSearchCompactJSON outputs results in minimal JSON format (without content)
-func outputSearchCompactJSON(results []store.SearchResult, enrichments []rpgEnrichment) error {
+// captureSearchCompactJSON returns compact JSON-encoded results as a string.
+func captureSearchCompactJSON(results []store.SearchResult, enrichments []rpgEnrichment) (string, error) {
 	jsonResults := make([]SearchResultCompactJSON, len(results))
 	for i, r := range results {
 		jsonResults[i] = SearchResultCompactJSON{
@@ -290,22 +346,17 @@ func outputSearchCompactJSON(results []store.SearchResult, enrichments []rpgEnri
 			SymbolName:  enrichments[i].SymbolName,
 		}
 	}
-
-	encoder := json.NewEncoder(os.Stdout)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(jsonResults)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(jsonResults); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
-// outputSearchErrorJSON outputs an error in JSON format
-func outputSearchErrorJSON(err error) error {
-	encoder := json.NewEncoder(os.Stdout)
-	encoder.SetIndent("", "  ")
-	_ = encoder.Encode(map[string]string{"error": err.Error()})
-	return nil
-}
-
-// outputSearchTOON outputs results in TOON format for AI agents
-func outputSearchTOON(results []store.SearchResult, enrichments []rpgEnrichment) error {
+// captureSearchTOON returns TOON-encoded results as a string.
+func captureSearchTOON(results []store.SearchResult, enrichments []rpgEnrichment) (string, error) {
 	toonResults := make([]SearchResultJSON, len(results))
 	for i, r := range results {
 		toonResults[i] = SearchResultJSON{
@@ -318,17 +369,15 @@ func outputSearchTOON(results []store.SearchResult, enrichments []rpgEnrichment)
 			SymbolName:  enrichments[i].SymbolName,
 		}
 	}
-
 	output, err := gotoon.Encode(toonResults)
 	if err != nil {
-		return fmt.Errorf("failed to encode TOON: %w", err)
+		return "", fmt.Errorf("failed to encode TOON: %w", err)
 	}
-	fmt.Println(output)
-	return nil
+	return output + "\n", nil
 }
 
-// outputSearchCompactTOON outputs results in minimal TOON format (without content)
-func outputSearchCompactTOON(results []store.SearchResult, enrichments []rpgEnrichment) error {
+// captureSearchCompactTOON returns compact TOON-encoded results as a string.
+func captureSearchCompactTOON(results []store.SearchResult, enrichments []rpgEnrichment) (string, error) {
 	toonResults := make([]SearchResultCompactJSON, len(results))
 	for i, r := range results {
 		toonResults[i] = SearchResultCompactJSON{
@@ -340,12 +389,18 @@ func outputSearchCompactTOON(results []store.SearchResult, enrichments []rpgEnri
 			SymbolName:  enrichments[i].SymbolName,
 		}
 	}
-
 	output, err := gotoon.Encode(toonResults)
 	if err != nil {
-		return fmt.Errorf("failed to encode TOON: %w", err)
+		return "", fmt.Errorf("failed to encode TOON: %w", err)
 	}
-	fmt.Println(output)
+	return output + "\n", nil
+}
+
+// outputSearchErrorJSON outputs an error in JSON format
+func outputSearchErrorJSON(err error) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	_ = encoder.Encode(map[string]string{"error": err.Error()})
 	return nil
 }
 
@@ -513,18 +568,34 @@ func runWorkspaceSearch(ctx context.Context, query string, projects []string, pa
 
 	// JSON output mode
 	if searchJSON {
+		var outputStr string
+		var err error
 		if searchCompact {
-			return outputSearchCompactJSON(results, enrichments)
+			outputStr, err = captureSearchCompactJSON(results, enrichments)
+		} else {
+			outputStr, err = captureSearchJSON(results, enrichments)
 		}
-		return outputSearchJSON(results, enrichments)
+		if err != nil {
+			return err
+		}
+		fmt.Print(outputStr)
+		return nil
 	}
 
 	// TOON output mode
 	if searchTOON {
+		var outputStr string
+		var err error
 		if searchCompact {
-			return outputSearchCompactTOON(results, enrichments)
+			outputStr, err = captureSearchCompactTOON(results, enrichments)
+		} else {
+			outputStr, err = captureSearchTOON(results, enrichments)
 		}
-		return outputSearchTOON(results, enrichments)
+		if err != nil {
+			return err
+		}
+		fmt.Print(outputStr)
+		return nil
 	}
 
 	if len(results) == 0 {

--- a/cli/stats.go
+++ b/cli/stats.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"github.com/yoanbernabeu/grepai/config"
+	"github.com/yoanbernabeu/grepai/stats"
+)
+
+var (
+	statsJSON    bool
+	statsHistory bool
+	statsLimit   int
+)
+
+var statsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show token savings achieved by using grepai",
+	Long: `Display a summary of token savings achieved by grepai compared to
+a traditional grep-based workflow.
+
+Every successful search and trace command records an entry locally in
+.grepai/stats.json. This command aggregates those entries and shows
+how many tokens (and optionally dollars) have been saved.`,
+	RunE: runStats,
+}
+
+func init() {
+	rootCmd.AddCommand(statsCmd)
+	statsCmd.Flags().BoolVarP(&statsJSON, "json", "j", false, "Output results in JSON format")
+	statsCmd.Flags().BoolVar(&statsHistory, "history", false, "Show per-day history breakdown")
+	statsCmd.Flags().IntVarP(&statsLimit, "limit", "l", 30, "Max days shown with --history")
+}
+
+func runStats(cmd *cobra.Command, args []string) error {
+	projectRoot, err := config.FindProjectRoot()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(projectRoot)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	statsPath := stats.StatsPath(projectRoot)
+	entries, err := stats.ReadAll(statsPath)
+	if err != nil {
+		return fmt.Errorf("failed to read stats: %w", err)
+	}
+
+	if len(entries) == 0 {
+		fmt.Println("No stats recorded yet.")
+		fmt.Println("Run a search or trace command to start tracking token savings.")
+		return nil
+	}
+
+	summary := stats.Summarize(entries, cfg.Embedder.Provider)
+
+	if statsJSON {
+		return outputStatsJSON(summary, entries)
+	}
+
+	return outputStatsHuman(summary, entries, cfg.Embedder.Provider)
+}
+
+// outputStatsJSON renders the summary (and optional history) as JSON.
+func outputStatsJSON(summary stats.Summary, entries []stats.Entry) error {
+	if !statsHistory {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(summary)
+	}
+
+	days := stats.HistoryByDay(entries)
+	if statsLimit > 0 && len(days) > statsLimit {
+		days = days[:statsLimit]
+	}
+
+	out := struct {
+		Summary stats.Summary      `json:"summary"`
+		History []stats.DaySummary `json:"history"`
+	}{
+		Summary: summary,
+		History: days,
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+// outputStatsHuman renders the summary using lipgloss styles.
+func outputStatsHuman(summary stats.Summary, entries []stats.Entry, provider string) error {
+	// Styles
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Width(22)
+	valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("229")).Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		Padding(1, 2)
+
+	content := headerStyle.Render("grepai stats — Token Savings Report") + "\n\n"
+
+	content += labelStyle.Render("Total queries") + valueStyle.Render(fmt.Sprintf("%d", summary.TotalQueries)) + "\n"
+	content += labelStyle.Render("Tokens (grepai)") + valueStyle.Render(formatInt(summary.OutputTokens)) + "\n"
+	content += labelStyle.Render("Tokens (grep est.)") + valueStyle.Render(formatInt(summary.GrepTokens)) + "\n"
+	content += labelStyle.Render("Tokens saved") +
+		valueStyle.Render(fmt.Sprintf("%s  ▲ %.1f%%", formatInt(summary.TokensSaved), summary.SavingsPct)) + "\n"
+
+	if summary.CostSavedUSD != nil {
+		content += labelStyle.Render("Est. cost saved") +
+			valueStyle.Render(fmt.Sprintf("$%.4f", *summary.CostSavedUSD)) +
+			dimStyle.Render("  (cloud provider)") + "\n"
+	}
+
+	// Command breakdown
+	content += "\n"
+	cmdLine := "By command:  "
+	for _, k := range []string{"search", "trace-callers", "trace-callees", "trace-graph"} {
+		if v := summary.ByCommandType[k]; v > 0 {
+			cmdLine += fmt.Sprintf("%s %d · ", k, v)
+		}
+	}
+	content += dimStyle.Render(trimSuffix(cmdLine, " · ")) + "\n"
+
+	modeLine := "By mode:     "
+	for _, k := range []string{"full", "compact", "toon"} {
+		if v := summary.ByOutputMode[k]; v > 0 {
+			modeLine += fmt.Sprintf("%s %d · ", k, v)
+		}
+	}
+	content += dimStyle.Render(trimSuffix(modeLine, " · ")) + "\n"
+
+	fmt.Println(boxStyle.Render(content))
+
+	if statsHistory {
+		printHistoryTable(entries, dimStyle, valueStyle)
+	}
+
+	return nil
+}
+
+func printHistoryTable(entries []stats.Entry, dimStyle, valueStyle lipgloss.Style) {
+	days := stats.HistoryByDay(entries)
+	if statsLimit > 0 && len(days) > statsLimit {
+		days = days[:statsLimit]
+	}
+
+	colDate := lipgloss.NewStyle().Width(14)
+	colNum := lipgloss.NewStyle().Width(10)
+	colSaved := lipgloss.NewStyle().Width(16)
+	colPct := lipgloss.NewStyle().Width(10)
+
+	header := dimStyle.Render(
+		colDate.Render("Date") +
+			colNum.Render("Queries") +
+			colSaved.Render("Tokens saved") +
+			colPct.Render("Savings"),
+	)
+	sep := dimStyle.Render(fmt.Sprintf("%-14s %-10s %-16s %-10s", "──────────────", "─────────", "───────────────", "────────"))
+	fmt.Println(header)
+	fmt.Println(sep)
+
+	for _, d := range days {
+		pct := 0.0
+		if d.GrepTokens > 0 {
+			pct = float64(d.TokensSaved) / float64(d.GrepTokens) * 100
+		}
+		row := colDate.Render(d.Date) +
+			colNum.Render(fmt.Sprintf("%d", d.QueryCount)) +
+			colSaved.Render(formatInt(d.TokensSaved)) +
+			colPct.Render(fmt.Sprintf("%.1f%%", pct))
+		fmt.Println(valueStyle.Render(row))
+	}
+}
+
+func formatInt(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	s := fmt.Sprintf("%d", n)
+	result := ""
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			result += ","
+		}
+		result += string(c)
+	}
+	return result
+}
+
+func trimSuffix(s, suffix string) string {
+	if len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix {
+		return s[:len(s)-len(suffix)]
+	}
+	return s
+}

--- a/cli/trace.go
+++ b/cli/trace.go
@@ -1,16 +1,19 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
+	"time"
 
 	"github.com/alpkeskin/gotoon"
 	"github.com/spf13/cobra"
 	"github.com/yoanbernabeu/grepai/config"
+	"github.com/yoanbernabeu/grepai/embedder"
 	"github.com/yoanbernabeu/grepai/rpg"
+	gstats "github.com/yoanbernabeu/grepai/stats"
 	"github.com/yoanbernabeu/grepai/trace"
 )
 
@@ -137,20 +140,36 @@ func runTraceCallers(cmd *cobra.Command, args []string) error {
 
 		if result.Symbol == nil {
 			if traceJSON {
-				return outputJSON(result)
+				fmt.Print(captureJSON(result))
+				return nil
 			}
 			if traceTOON {
-				return outputTOON(result)
+				{
+					s, e := captureTOON(result)
+					if e != nil {
+						return e
+					}
+					fmt.Print(s)
+					return nil
+				}
 			}
 			fmt.Printf("No symbol found: %s\n", symbolName)
 			return nil
 		}
 
 		if traceJSON {
-			return outputJSON(result)
+			fmt.Print(captureJSON(result))
+			return nil
 		}
 		if traceTOON {
-			return outputTOON(result)
+			{
+				s, e := captureTOON(result)
+				if e != nil {
+					return e
+				}
+				fmt.Print(s)
+				return nil
+			}
 		}
 		return displayCallersResult(result)
 	}
@@ -182,10 +201,18 @@ func runTraceCallers(cmd *cobra.Command, args []string) error {
 	if len(symbols) == 0 {
 		emptyResult := trace.TraceResult{Query: symbolName, Mode: traceMode}
 		if traceJSON {
-			return outputJSON(emptyResult)
+			fmt.Print(captureJSON(emptyResult))
+			return nil
 		}
 		if traceTOON {
-			return outputTOON(emptyResult)
+			{
+				s, e := captureTOON(emptyResult)
+				if e != nil {
+					return e
+				}
+				fmt.Print(s)
+				return nil
+			}
 		}
 		fmt.Printf("No symbol found: %s\n", symbolName)
 		return nil
@@ -229,13 +256,26 @@ func runTraceCallers(cmd *cobra.Command, args []string) error {
 	}
 
 	if traceJSON {
-		return outputJSON(result)
+		outputStr := captureJSON(result)
+		fmt.Print(outputStr)
+		recordTraceStats(projectRoot, gstats.TraceCallers, len(result.Callers), outputStr)
+		return nil
 	}
 	if traceTOON {
-		return outputTOON(result)
+		outputStr, err := captureTOON(result)
+		if err != nil {
+			return err
+		}
+		fmt.Print(outputStr)
+		recordTraceStats(projectRoot, gstats.TraceCallers, len(result.Callers), outputStr)
+		return nil
 	}
 
-	return displayCallersResult(result)
+	if err := displayCallersResult(result); err != nil {
+		return err
+	}
+	recordTraceStats(projectRoot, gstats.TraceCallers, len(result.Callers), "")
+	return nil
 }
 
 func runTraceCallees(cmd *cobra.Command, args []string) error {
@@ -284,20 +324,36 @@ func runTraceCallees(cmd *cobra.Command, args []string) error {
 
 		if result.Symbol == nil {
 			if traceJSON {
-				return outputJSON(result)
+				fmt.Print(captureJSON(result))
+				return nil
 			}
 			if traceTOON {
-				return outputTOON(result)
+				{
+					s, e := captureTOON(result)
+					if e != nil {
+						return e
+					}
+					fmt.Print(s)
+					return nil
+				}
 			}
 			fmt.Printf("No symbol found: %s\n", symbolName)
 			return nil
 		}
 
 		if traceJSON {
-			return outputJSON(result)
+			fmt.Print(captureJSON(result))
+			return nil
 		}
 		if traceTOON {
-			return outputTOON(result)
+			{
+				s, e := captureTOON(result)
+				if e != nil {
+					return e
+				}
+				fmt.Print(s)
+				return nil
+			}
 		}
 		return displayCalleesResult(result)
 	}
@@ -328,10 +384,18 @@ func runTraceCallees(cmd *cobra.Command, args []string) error {
 	if len(symbols) == 0 {
 		emptyResult := trace.TraceResult{Query: symbolName, Mode: traceMode}
 		if traceJSON {
-			return outputJSON(emptyResult)
+			fmt.Print(captureJSON(emptyResult))
+			return nil
 		}
 		if traceTOON {
-			return outputTOON(emptyResult)
+			{
+				s, e := captureTOON(emptyResult)
+				if e != nil {
+					return e
+				}
+				fmt.Print(s)
+				return nil
+			}
 		}
 		fmt.Printf("No symbol found: %s\n", symbolName)
 		return nil
@@ -374,13 +438,26 @@ func runTraceCallees(cmd *cobra.Command, args []string) error {
 	}
 
 	if traceJSON {
-		return outputJSON(result)
+		outputStr := captureJSON(result)
+		fmt.Print(outputStr)
+		recordTraceStats(projectRoot, gstats.TraceCallees, len(result.Callees), outputStr)
+		return nil
 	}
 	if traceTOON {
-		return outputTOON(result)
+		outputStr, err := captureTOON(result)
+		if err != nil {
+			return err
+		}
+		fmt.Print(outputStr)
+		recordTraceStats(projectRoot, gstats.TraceCallees, len(result.Callees), outputStr)
+		return nil
 	}
 
-	return displayCalleesResult(result)
+	if err := displayCalleesResult(result); err != nil {
+		return err
+	}
+	recordTraceStats(projectRoot, gstats.TraceCallees, len(result.Callees), "")
+	return nil
 }
 
 func runTraceGraph(cmd *cobra.Command, args []string) error {
@@ -434,10 +511,18 @@ func runTraceGraph(cmd *cobra.Command, args []string) error {
 		}
 
 		if traceJSON {
-			return outputJSON(result)
+			fmt.Print(captureJSON(result))
+			return nil
 		}
 		if traceTOON {
-			return outputTOON(result)
+			{
+				s, e := captureTOON(result)
+				if e != nil {
+					return e
+				}
+				fmt.Print(s)
+				return nil
+			}
 		}
 		return displayGraphResult(result)
 	}
@@ -476,14 +561,32 @@ func runTraceGraph(cmd *cobra.Command, args []string) error {
 		enrichTraceWithRPG(projectRoot, cfg, &result)
 	}
 
-	if traceJSON {
-		return outputJSON(result)
-	}
-	if traceTOON {
-		return outputTOON(result)
+	nodeCount := 0
+	if result.Graph != nil {
+		nodeCount = len(result.Graph.Nodes)
 	}
 
-	return displayGraphResult(result)
+	if traceJSON {
+		outputStr := captureJSON(result)
+		fmt.Print(outputStr)
+		recordTraceStats(projectRoot, gstats.TraceGraph, nodeCount, outputStr)
+		return nil
+	}
+	if traceTOON {
+		outputStr, err := captureTOON(result)
+		if err != nil {
+			return err
+		}
+		fmt.Print(outputStr)
+		recordTraceStats(projectRoot, gstats.TraceGraph, nodeCount, outputStr)
+		return nil
+	}
+
+	if err := displayGraphResult(result); err != nil {
+		return err
+	}
+	recordTraceStats(projectRoot, gstats.TraceGraph, nodeCount, "")
+	return nil
 }
 
 // enrichTraceWithRPG enriches all symbols in a TraceResult with RPG feature paths.
@@ -542,19 +645,40 @@ func enrichTraceWithRPG(projectRoot string, cfg *config.Config, result *trace.Tr
 	}
 }
 
-func outputJSON(result trace.TraceResult) error {
-	enc := json.NewEncoder(os.Stdout)
+// captureJSON serializes a TraceResult to a JSON string without writing to stdout.
+func captureJSON(result trace.TraceResult) string {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
-	return enc.Encode(result)
+	_ = enc.Encode(result)
+	return buf.String()
 }
 
-func outputTOON(result trace.TraceResult) error {
+// captureTOON serializes a TraceResult to a TOON string without writing to stdout.
+func captureTOON(result trace.TraceResult) (string, error) {
 	output, err := gotoon.Encode(result)
 	if err != nil {
-		return fmt.Errorf("failed to encode TOON: %w", err)
+		return "", fmt.Errorf("failed to encode TOON: %w", err)
 	}
-	fmt.Println(output)
-	return nil
+	return output + "\n", nil
+}
+
+// recordTraceStats fires a goroutine to record a trace stats entry without blocking.
+func recordTraceStats(projectRoot, commandType string, resultCount int, outputStr string) {
+	rec := gstats.NewRecorder(projectRoot)
+	entry := gstats.Entry{
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		CommandType:  commandType,
+		OutputMode:   outputModeFromFlags(traceJSON, traceTOON, false),
+		ResultCount:  resultCount,
+		OutputTokens: embedder.EstimateTokens(outputStr),
+		GrepTokens:   gstats.GrepEquivalentTokens(resultCount),
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_ = rec.Record(ctx, entry)
+	}()
 }
 
 func displayCallersResult(result trace.TraceResult) error {

--- a/cli/trace_test.go
+++ b/cli/trace_test.go
@@ -203,28 +203,12 @@ func TestOutputJSON_should_produce_valid_json(t *testing.T) {
 		},
 	}
 
-	// Capture stdout
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := outputJSON(result)
-
-	w.Close()
-	os.Stdout = old
-
-	if err != nil {
-		t.Fatalf("outputJSON() failed: %v", err)
-	}
-
-	var buf bytes.Buffer
-	buf.ReadFrom(r)
-	output := buf.String()
+	output := captureJSON(result)
 
 	// Verify it's valid JSON
 	var decoded trace.TraceResult
 	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
-		t.Fatalf("outputJSON() produced invalid JSON: %v\nOutput: %s", err, output)
+		t.Fatalf("captureJSON() produced invalid JSON: %v\nOutput: %s", err, output)
 	}
 	if decoded.Query != "TestSymbol" {
 		t.Errorf("decoded query = %q, want %q", decoded.Query, "TestSymbol")

--- a/search/path_normalizer_test.go
+++ b/search/path_normalizer_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -56,6 +57,41 @@ func TestNormalizeProjectPathPrefix(t *testing.T) {
 				t.Fatalf("NormalizeProjectPathPrefix() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeForPathMatch_RelativePath(t *testing.T) {
+	// Branche filepath.Abs : projectRoot est un chemin relatif.
+	// On obtient le workdir courant pour construire le pathPrefix absolu attendu.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	// projectRoot relatif pointant vers le répertoire courant
+	projectRoot := "."
+	// pathPrefix absolu sous le workdir courant
+	pathPrefix := filepath.Join(wd, "path_normalizer.go")
+
+	got, err := NormalizeProjectPathPrefix(pathPrefix, projectRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "path_normalizer.go" {
+		t.Fatalf("got %q, want %q", got, "path_normalizer.go")
+	}
+}
+
+func TestNormalizeForPathMatch_NonExistentRoot(t *testing.T) {
+	// Branche EvalSymlinks error : root does not exist, fallback to unresolved path.
+	projectRoot := "/nonexistent/root"
+	pathPrefix := "/nonexistent/root/src/foo.go"
+
+	got, err := NormalizeProjectPathPrefix(pathPrefix, projectRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "src/foo.go" {
+		t.Fatalf("got %q, want %q", got, "src/foo.go")
 	}
 }
 

--- a/stats/doc.go
+++ b/stats/doc.go
@@ -1,0 +1,4 @@
+// Package stats provides token savings tracking for grepai commands.
+// It records each search and trace invocation locally and computes
+// savings estimates compared to a traditional grep-based workflow.
+package stats

--- a/stats/flock_unix.go
+++ b/stats/flock_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package stats
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func flockExclusive(f *os.File) error {
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("failed to acquire exclusive lock: %w", err)
+	}
+	return nil
+}
+
+func funlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/stats/flock_unix_test.go
+++ b/stats/flock_unix_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package stats
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFlockExclusive_Error(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "flock-test-*")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	// Fermer le fichier pour invalider le fd — syscall.Flock retournera EBADF.
+	f.Close()
+
+	if err := flockExclusive(f); err == nil {
+		t.Fatal("flockExclusive() expected error on closed fd, got nil")
+	}
+}

--- a/stats/flock_windows.go
+++ b/stats/flock_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package stats
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32    = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx = modkernel32.NewProc("LockFileEx")
+	procUnlockFile = modkernel32.NewProc("UnlockFileEx")
+)
+
+const winLockfileExclusiveLock = 0x00000002
+
+func flockExclusive(f *os.File) error {
+	var overlapped syscall.Overlapped
+	ret, _, err := procLockFileEx.Call(
+		f.Fd(),
+		uintptr(winLockfileExclusiveLock),
+		0, 1, 0,
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if ret == 0 {
+		return fmt.Errorf("failed to acquire exclusive lock: %w", err)
+	}
+	return nil
+}
+
+func funlock(f *os.File) error {
+	var overlapped syscall.Overlapped
+	ret, _, err := procUnlockFile.Call(
+		f.Fd(),
+		0, 1, 0,
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if ret == 0 {
+		return fmt.Errorf("failed to unlock file: %w", err)
+	}
+	return nil
+}

--- a/stats/reader.go
+++ b/stats/reader.go
@@ -1,0 +1,118 @@
+package stats
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// ReadAll reads all entries from the NDJSON stats file at statsPath.
+// Malformed lines are skipped with a warning to stderr.
+// Returns an empty slice (not an error) when the file does not exist.
+func ReadAll(statsPath string) ([]Entry, error) {
+	f, err := os.Open(statsPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stats: open: %w", err)
+	}
+	defer f.Close()
+
+	var entries []Entry
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			fmt.Fprintf(os.Stderr, "stats: skipping malformed line %d: %v\n", lineNum, err)
+			continue
+		}
+		entries = append(entries, e)
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return entries, fmt.Errorf("stats: read: %w", err)
+	}
+	return entries, nil
+}
+
+// Summarize aggregates entries into a Summary.
+// CostSavedUSD is set only for cloud providers.
+func Summarize(entries []Entry, provider string) Summary {
+	s := Summary{
+		ByCommandType: map[string]int{
+			Search:       0,
+			TraceCallers: 0,
+			TraceCallees: 0,
+			TraceGraph:   0,
+		},
+		ByOutputMode: map[string]int{
+			Full:    0,
+			Compact: 0,
+			Toon:    0,
+		},
+	}
+
+	for _, e := range entries {
+		s.TotalQueries++
+		s.OutputTokens += e.OutputTokens
+		s.GrepTokens += e.GrepTokens
+		s.ByCommandType[e.CommandType]++
+		s.ByOutputMode[e.OutputMode]++
+	}
+
+	s.TokensSaved = s.GrepTokens - s.OutputTokens
+	if s.GrepTokens > 0 {
+		s.SavingsPct = float64(s.TokensSaved) / float64(s.GrepTokens) * 100
+	}
+
+	if IsCloudProvider(provider) {
+		saved := float64(s.TokensSaved) / 1_000_000 * CostPerMTokenUSD
+		s.CostSavedUSD = &saved
+	}
+
+	return s
+}
+
+// HistoryByDay groups entries by calendar day (UTC) and returns a slice
+// sorted in descending order (most recent first).
+func HistoryByDay(entries []Entry) []DaySummary {
+	byDate := map[string]*DaySummary{}
+
+	for _, e := range entries {
+		day := ""
+		if len(e.Timestamp) >= 10 {
+			day = e.Timestamp[:10] // "YYYY-MM-DD"
+		} else {
+			day = "unknown"
+		}
+		d, ok := byDate[day]
+		if !ok {
+			d = &DaySummary{Date: day}
+			byDate[day] = d
+		}
+		d.QueryCount++
+		d.OutputTokens += e.OutputTokens
+		d.GrepTokens += e.GrepTokens
+		d.TokensSaved += e.GrepTokens - e.OutputTokens
+	}
+
+	days := make([]DaySummary, 0, len(byDate))
+	for _, d := range byDate {
+		days = append(days, *d)
+	}
+	sort.Slice(days, func(i, j int) bool {
+		return days[i].Date > days[j].Date
+	})
+	return days
+}

--- a/stats/recorder.go
+++ b/stats/recorder.go
@@ -1,0 +1,65 @@
+package stats
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Recorder appends stat entries to the local NDJSON stats file.
+type Recorder struct {
+	statsPath string
+	lockPath  string
+}
+
+// NewRecorder creates a Recorder that writes to the stats file inside projectRoot.
+func NewRecorder(projectRoot string) *Recorder {
+	return &Recorder{
+		statsPath: StatsPath(projectRoot),
+		lockPath:  LockPath(projectRoot),
+	}
+}
+
+// Record appends one entry to the stats NDJSON file.
+// The write is protected by a file lock for cross-process safety.
+// If the context is canceled or the write fails, the error is returned
+// but the caller is expected to discard it (fire-and-forget pattern).
+func (r *Recorder) Record(ctx context.Context, e Entry) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	line, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("stats: marshal entry: %w", err)
+	}
+	line = append(line, '\n')
+
+	lockFile, err := os.OpenFile(r.lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		// Proceed without locking rather than failing the caller.
+		return r.appendLine(line)
+	}
+	defer lockFile.Close()
+
+	if err := flockExclusive(lockFile); err != nil {
+		return r.appendLine(line)
+	}
+	defer func() { _ = funlock(lockFile) }()
+
+	return r.appendLine(line)
+}
+
+func (r *Recorder) appendLine(line []byte) error {
+	f, err := os.OpenFile(r.statsPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("stats: open file: %w", err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(line)
+	return err
+}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -1,0 +1,107 @@
+package stats
+
+import "path/filepath"
+
+// CommandType represents the type of grepai command that was executed.
+type CommandType = string
+
+const (
+	Search       CommandType = "search"
+	TraceCallers CommandType = "trace-callers"
+	TraceCallees CommandType = "trace-callees"
+	TraceGraph   CommandType = "trace-graph"
+)
+
+// OutputMode represents the output format used for the command result.
+type OutputMode = string
+
+const (
+	Full    OutputMode = "full"
+	Compact OutputMode = "compact"
+	Toon    OutputMode = "toon"
+)
+
+// GrepExpansionFactor is the multiplier applied to result count when estimating
+// how many tokens a grep-based workflow would have consumed. A factor of 3
+// accounts for grep returning full file sections rather than isolated chunks.
+const GrepExpansionFactor = 3
+
+// DefaultChunkTokens is the default chunk size in tokens used for grep estimation.
+// Mirrors indexer.DefaultChunkSize.
+const DefaultChunkTokens = 512
+
+// CostPerMTokenUSD is the reference cost per million input tokens used for
+// estimating USD savings on cloud providers (conservative middle-ground rate).
+const CostPerMTokenUSD = 5.00
+
+// MinGrepTokens is the minimum grep-equivalent token estimate when result count
+// is zero, to avoid division-by-zero in savings percentage.
+const MinGrepTokens = 50
+
+// StatsFileName is the name of the NDJSON stats file inside .grepai/.
+const StatsFileName = "stats.json"
+
+// LockFileName is the name of the lock file used for safe concurrent writes.
+const LockFileName = "stats.json.lock"
+
+// cloudProviders is the set of provider names that have an associated token cost.
+var cloudProviders = map[string]bool{
+	"openai":     true,
+	"openrouter": true,
+	"synthetic":  true,
+}
+
+// IsCloudProvider returns true when the given provider name has a token cost.
+func IsCloudProvider(provider string) bool {
+	return cloudProviders[provider]
+}
+
+// GrepEquivalentTokens estimates how many tokens a grep-based workflow would
+// have consumed for a given number of results.
+func GrepEquivalentTokens(resultCount int) int {
+	if resultCount == 0 {
+		return MinGrepTokens
+	}
+	return resultCount * DefaultChunkTokens * GrepExpansionFactor
+}
+
+// Entry represents a single recorded command event.
+type Entry struct {
+	Timestamp    string `json:"timestamp"`    // RFC3339 UTC
+	CommandType  string `json:"command_type"` // search | trace-callers | trace-callees | trace-graph
+	OutputMode   string `json:"output_mode"`  // full | compact | toon
+	ResultCount  int    `json:"result_count"`
+	OutputTokens int    `json:"output_tokens"` // estimated tokens in grepai output
+	GrepTokens   int    `json:"grep_tokens"`   // estimated tokens for grep equivalent
+}
+
+// Summary is the aggregated view of all recorded entries.
+type Summary struct {
+	TotalQueries  int            `json:"total_queries"`
+	OutputTokens  int            `json:"output_tokens"`
+	GrepTokens    int            `json:"grep_tokens"`
+	TokensSaved   int            `json:"tokens_saved"`
+	SavingsPct    float64        `json:"savings_pct"`
+	CostSavedUSD  *float64       `json:"cost_saved_usd"`
+	ByCommandType map[string]int `json:"by_command_type"`
+	ByOutputMode  map[string]int `json:"by_output_mode"`
+}
+
+// DaySummary holds per-day aggregated stats for the --history view.
+type DaySummary struct {
+	Date         string `json:"date"`
+	QueryCount   int    `json:"query_count"`
+	OutputTokens int    `json:"output_tokens"`
+	GrepTokens   int    `json:"grep_tokens"`
+	TokensSaved  int    `json:"tokens_saved"`
+}
+
+// StatsPath returns the absolute path of the stats NDJSON file.
+func StatsPath(projectRoot string) string {
+	return filepath.Join(projectRoot, StatsFileName)
+}
+
+// LockPath returns the absolute path of the stats lock file.
+func LockPath(projectRoot string) string {
+	return filepath.Join(projectRoot, LockFileName)
+}

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1,0 +1,252 @@
+package stats_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/yoanbernabeu/grepai/stats"
+)
+
+// ---- helpers ----
+
+func writeStatsFile(t *testing.T, dir string, lines []string) {
+	t.Helper()
+	path := filepath.Join(dir, stats.StatsFileName)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create stats file: %v", err)
+	}
+	defer f.Close()
+	for _, l := range lines {
+		f.WriteString(l + "\n")
+	}
+}
+
+func entryJSON(t *testing.T, e stats.Entry) string {
+	t.Helper()
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal entry: %v", err)
+	}
+	return string(b)
+}
+
+func makeEntry(ts, ct, mode string, results, out, grep int) stats.Entry {
+	return stats.Entry{
+		Timestamp:    ts,
+		CommandType:  ct,
+		OutputMode:   mode,
+		ResultCount:  results,
+		OutputTokens: out,
+		GrepTokens:   grep,
+	}
+}
+
+// ---- GrepEquivalentTokens ----
+
+func TestGrepEquivalentTokens_NonZero(t *testing.T) {
+	got := stats.GrepEquivalentTokens(4)
+	want := 4 * stats.DefaultChunkTokens * stats.GrepExpansionFactor
+	if got != want {
+		t.Errorf("GrepEquivalentTokens(4) = %d, want %d", got, want)
+	}
+}
+
+func TestGrepEquivalentTokens_Zero(t *testing.T) {
+	got := stats.GrepEquivalentTokens(0)
+	if got != stats.MinGrepTokens {
+		t.Errorf("GrepEquivalentTokens(0) = %d, want %d", got, stats.MinGrepTokens)
+	}
+}
+
+// ---- Round-trip Record → ReadAll ----
+
+func TestRecordReadAll_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	rec := stats.NewRecorder(dir)
+	ctx := context.Background()
+
+	entries := []stats.Entry{
+		makeEntry(time.Now().UTC().Format(time.RFC3339), stats.Search, stats.Compact, 5, 100, 2560),
+		makeEntry(time.Now().UTC().Format(time.RFC3339), stats.TraceCallers, stats.Full, 3, 300, 1536),
+	}
+	for _, e := range entries {
+		if err := rec.Record(ctx, e); err != nil {
+			t.Fatalf("Record: %v", err)
+		}
+	}
+
+	got, err := stats.ReadAll(stats.StatsPath(dir))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(got) != len(entries) {
+		t.Fatalf("ReadAll returned %d entries, want %d", len(got), len(entries))
+	}
+	for i, e := range got {
+		if e.CommandType != entries[i].CommandType {
+			t.Errorf("[%d] CommandType = %q, want %q", i, e.CommandType, entries[i].CommandType)
+		}
+		if e.OutputTokens != entries[i].OutputTokens {
+			t.Errorf("[%d] OutputTokens = %d, want %d", i, e.OutputTokens, entries[i].OutputTokens)
+		}
+	}
+}
+
+// ---- ReadAll: file not found ----
+
+func TestReadAll_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	entries, err := stats.ReadAll(filepath.Join(dir, stats.StatsFileName))
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected empty slice, got %d entries", len(entries))
+	}
+}
+
+// ---- ReadAll: corrupted line is skipped ----
+
+func TestReadAll_CorruptedLineSkipped(t *testing.T) {
+	dir := t.TempDir()
+	good := makeEntry("2026-02-22T10:00:00Z", stats.Search, stats.Full, 2, 80, 1024)
+	writeStatsFile(t, dir, []string{
+		entryJSON(t, good),
+		"THIS IS NOT JSON",
+		entryJSON(t, good),
+	})
+
+	entries, err := stats.ReadAll(stats.StatsPath(dir))
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 valid entries, got %d", len(entries))
+	}
+}
+
+// ---- Summarize ----
+
+func TestSummarize_Totals(t *testing.T) {
+	entries := []stats.Entry{
+		makeEntry("2026-02-22T10:00:00Z", stats.Search, stats.Compact, 5, 100, 2560),
+		makeEntry("2026-02-22T11:00:00Z", stats.TraceCallers, stats.Full, 3, 300, 1536),
+	}
+	s := stats.Summarize(entries, "ollama")
+
+	if s.TotalQueries != 2 {
+		t.Errorf("TotalQueries = %d, want 2", s.TotalQueries)
+	}
+	if s.OutputTokens != 400 {
+		t.Errorf("OutputTokens = %d, want 400", s.OutputTokens)
+	}
+	if s.GrepTokens != 4096 {
+		t.Errorf("GrepTokens = %d, want 4096", s.GrepTokens)
+	}
+	if s.TokensSaved != 3696 {
+		t.Errorf("TokensSaved = %d, want 3696", s.TokensSaved)
+	}
+}
+
+func TestSummarize_SavingsPct(t *testing.T) {
+	entries := []stats.Entry{
+		makeEntry("2026-02-22T10:00:00Z", stats.Search, stats.Full, 4, 200, 2048),
+	}
+	s := stats.Summarize(entries, "openai")
+	want := float64(2048-200) / float64(2048) * 100
+	if s.SavingsPct < want-0.01 || s.SavingsPct > want+0.01 {
+		t.Errorf("SavingsPct = %.2f, want ~%.2f", s.SavingsPct, want)
+	}
+}
+
+func TestSummarize_NoGrepTokens_NoPanic(t *testing.T) {
+	entries := []stats.Entry{
+		makeEntry("2026-02-22T10:00:00Z", stats.Search, stats.Full, 0, 10, stats.MinGrepTokens),
+	}
+	s := stats.Summarize(entries, "ollama")
+	if s.SavingsPct < 0 {
+		t.Errorf("SavingsPct should not be negative")
+	}
+}
+
+// ---- Summarize: cloud vs local provider ----
+
+func TestSummarize_CloudProvider_CostSet(t *testing.T) {
+	entries := []stats.Entry{
+		makeEntry("2026-02-22T10:00:00Z", stats.Search, stats.Compact, 5, 100, 2560),
+	}
+	s := stats.Summarize(entries, "openai")
+	if s.CostSavedUSD == nil {
+		t.Fatal("expected CostSavedUSD to be non-nil for cloud provider")
+	}
+	if *s.CostSavedUSD <= 0 {
+		t.Errorf("CostSavedUSD = %f, want > 0", *s.CostSavedUSD)
+	}
+}
+
+func TestSummarize_LocalProvider_CostNil(t *testing.T) {
+	entries := []stats.Entry{
+		makeEntry("2026-02-22T10:00:00Z", stats.Search, stats.Full, 5, 100, 2560),
+	}
+	for _, provider := range []string{"ollama", "lmstudio"} {
+		s := stats.Summarize(entries, provider)
+		if s.CostSavedUSD != nil {
+			t.Errorf("provider %q: expected CostSavedUSD nil, got %v", provider, *s.CostSavedUSD)
+		}
+	}
+}
+
+// ---- HistoryByDay ----
+
+func TestHistoryByDay_Grouping(t *testing.T) {
+	entries := []stats.Entry{
+		makeEntry("2026-02-20T10:00:00Z", stats.Search, stats.Full, 2, 80, 1024),
+		makeEntry("2026-02-21T09:00:00Z", stats.Search, stats.Full, 3, 120, 1536),
+		makeEntry("2026-02-21T15:00:00Z", stats.TraceCallers, stats.Compact, 1, 40, 512),
+		makeEntry("2026-02-22T08:00:00Z", stats.Search, stats.Compact, 5, 100, 2560),
+	}
+	days := stats.HistoryByDay(entries)
+
+	if len(days) != 3 {
+		t.Fatalf("expected 3 days, got %d", len(days))
+	}
+	// Sorted descending
+	if days[0].Date != "2026-02-22" {
+		t.Errorf("days[0].Date = %q, want 2026-02-22", days[0].Date)
+	}
+	if days[1].Date != "2026-02-21" {
+		t.Errorf("days[1].Date = %q, want 2026-02-21", days[1].Date)
+	}
+	if days[1].QueryCount != 2 {
+		t.Errorf("days[1].QueryCount = %d, want 2", days[1].QueryCount)
+	}
+}
+
+func TestHistoryByDay_Empty(t *testing.T) {
+	days := stats.HistoryByDay(nil)
+	if len(days) != 0 {
+		t.Errorf("expected empty slice for nil entries")
+	}
+}
+
+// ---- IsCloudProvider ----
+
+func TestIsCloudProvider(t *testing.T) {
+	cloud := []string{"openai", "openrouter", "synthetic"}
+	for _, p := range cloud {
+		if !stats.IsCloudProvider(p) {
+			t.Errorf("IsCloudProvider(%q) = false, want true", p)
+		}
+	}
+	local := []string{"ollama", "lmstudio", ""}
+	for _, p := range local {
+		if stats.IsCloudProvider(p) {
+			t.Errorf("IsCloudProvider(%q) = true, want false", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces a privacy-first gains monitoring system for grepai. Every `search` and `trace` command now automatically records token usage metrics locally, and a new `grepai stats` command lets users visualize how much they save compared to a traditional grep-based workflow.

All data stays on the machine — nothing is ever sent to an external service.

---

## Motivation

Users had no visibility into the concrete value grepai brings over grep. This feature answers the question: *"How many tokens (and dollars) have I actually saved by using grepai?"*

---

## What's new

### New `stats/` package
- `Entry` — one record per search/trace command (timestamp, command type, output mode, result count, tokens consumed, grep-equivalent tokens)
- `Recorder` — appends entries as NDJSON to `.grepai/stats.json` using a file lock (cross-platform: `flock` on Unix, `LockFileEx` on Windows)
- `ReadAll` / `Summarize` / `HistoryByDay` — aggregation helpers
- `GrepEquivalentTokens(n)` — estimates what grep would have cost: `n × 512 tokens × 3` (expansion factor for context)
- Cost estimation for cloud providers (OpenAI, OpenRouter, Synthetic) at $5/M tokens; `nil` for local providers (Ollama, LM Studio)
- 13 unit tests with `-race`, all green

### New `grepai stats` command (`cli/stats.go`)

```
grepai stats [--json] [--history] [--limit N]
```

- Human-readable output with lipgloss (rounded border, colors)
- `--json` — structured JSON output for scripting/agents
- `--history` — per-day breakdown table
- `--limit N` — max days shown (default: 30)

### Auto-recording in `search` and `trace`

Stats are recorded **fire-and-forget** in a goroutine with a 100 ms timeout — zero impact on search/trace latency. Output is captured to a string (instead of writing directly to stdout) to enable token counting without stdout hijacking.

### MCP integration (`mcp/server.go`)

Stats are recorded for all MCP tool calls: `grepai_search`, `grepai_trace_callers`, `grepai_trace_callees`, `grepai_trace_graph`.
A new `grepai_stats` MCP tool allows AI agents to query savings programmatically.

---

## Example output

```
╭─────────────────────────────────────────────────────╮
│ grepai stats — Token Savings Report                 │
│                                                     │
│ Total queries      42                               │
│ Tokens (grepai)    8,320                            │
│ Tokens (grep est.) 64,512                           │
│ Tokens saved       56,192  ▲ 87.1%                  │
│ Est. cost saved    $0.2810  (cloud provider)        │
│                                                     │
│ By command:  search 38 · trace-callers 4            │
│ By mode:     compact 30 · full 12                   │
╰─────────────────────────────────────────────────────╯
```

---

## Files changed

| File | Change |
|------|--------|
| `stats/stats.go` | New — types, constants, helpers |
| `stats/recorder.go` | New — NDJSON append with file lock |
| `stats/reader.go` | New — read, summarize, history |
| `stats/flock_unix.go` | New — Unix file locking |
| `stats/flock_windows.go` | New — Windows file locking |
| `stats/stats_test.go` | New — 13 tests |
| `cli/stats.go` | New — `grepai stats` command |
| `cli/search.go` | Modified — capture output + fire-and-forget recording |
| `cli/trace.go` | Modified — capture output + fire-and-forget recording |
| `cli/trace_test.go` | Updated — adapted to renamed `captureJSON` |
| `mcp/server.go` | Modified — stats recording + `grepai_stats` tool |

---

## Testing

```bash
make test        # all packages pass with -race
make build       # binary builds clean
grepai stats --help
grepai stats --json
grepai stats --history --limit 7
```

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

**Test Configuration:**
- OS: Linux/Windows
- Go version:
- Embedding provider:

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style
- [x] I have run `golangci-lint run` and fixed any issues
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed
- [ ] I have added an entry to CHANGELOG.md (if applicable)
- [x] My changes generate no new warnings
- [x] All new and existing tests pass

