### PR TITLE
feat(indexer): add .grepaiignore support with negation patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`.grepaiignore` Support**: New `.grepaiignore` file allows overriding `.gitignore` rules for grepai indexing. Supports negation patterns (`!`) to re-include files excluded by `.gitignore`, with directory-level precedence for nested files (#107)
+
 ## [0.34.0] - 2026-02-24
 
 ### Added

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -118,9 +118,9 @@ func (l *livenessCheck) cleanup() {
 }
 
 const (
-	stopFilePrefix    = "grepai-stop-"
-	stopPollInterval  = 500 * time.Millisecond
-	stopStaleAfter    = 60 * time.Second
+	stopFilePrefix   = "grepai-stop-"
+	stopPollInterval = 500 * time.Millisecond
+	stopStaleAfter   = 60 * time.Second
 )
 
 // stopFilePath returns the path to the sentinel stop file for the given PID.

--- a/indexer/gitignore.go
+++ b/indexer/gitignore.go
@@ -34,10 +34,21 @@ type nestedMatcher struct {
 	baseDir string // relative path from project root (empty for root .gitignore)
 }
 
+// grepaiMatcher holds a pair of matchers for .grepaiignore files.
+// "full" uses original patterns (with negations) for the actual decision.
+// "any" uses all patterns converted to positive for detecting if the file has an opinion.
+type grepaiMatcher struct {
+	full    *ignore.GitIgnore // Matcher with original patterns (including negations)
+	any     *ignore.GitIgnore // Matcher with all patterns as positive (for detection)
+	baseDir string            // relative path from project root
+}
+
 type IgnoreMatcher struct {
-	projectRoot    string
-	nestedMatchers []nestedMatcher
-	extraDirs      []string
+	projectRoot        string
+	nestedMatchers     []nestedMatcher // .gitignore matchers
+	extraDirs          []string        // patterns from config
+	grepaiMatchers     []grepaiMatcher // .grepaiignore matchers
+	hasGrepaiNegations bool            // true if any .grepaiignore has ! patterns
 }
 
 func NewIgnoreMatcher(projectRoot string, extraIgnore []string, externalGitignore string) (*IgnoreMatcher, error) {
@@ -64,7 +75,7 @@ func NewIgnoreMatcher(projectRoot string, extraIgnore []string, externalGitignor
 		}
 	}
 
-	// Walk the project to find all .gitignore files
+	// Walk the project to find all .gitignore and .grepaiignore files
 	err := filepath.Walk(projectRoot, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil // Skip inaccessible paths
@@ -81,29 +92,50 @@ func NewIgnoreMatcher(projectRoot string, extraIgnore []string, externalGitignor
 			return nil
 		}
 
-		// Only process .gitignore files
-		if filepath.Base(path) != ".gitignore" {
-			return nil
+		baseName := filepath.Base(path)
+
+		// Process .gitignore files
+		if baseName == ".gitignore" {
+			gi, err := ignore.CompileIgnoreFile(path)
+			if err != nil {
+				return nil // Skip invalid .gitignore files
+			}
+
+			relPath, err := filepath.Rel(projectRoot, filepath.Dir(path))
+			if err != nil {
+				return nil
+			}
+			if relPath == "." {
+				relPath = ""
+			}
+
+			m.nestedMatchers = append(m.nestedMatchers, nestedMatcher{
+				matcher: gi,
+				baseDir: relPath,
+			})
 		}
 
-		gi, err := ignore.CompileIgnoreFile(path)
-		if err != nil {
-			return nil // Skip invalid .gitignore files
-		}
+		// Process .grepaiignore files
+		if baseName == ".grepaiignore" {
+			gm, hasNegations, err := compileGrepaiIgnoreFile(path)
+			if err != nil {
+				return nil // Skip invalid .grepaiignore files
+			}
 
-		// Get relative base directory
-		relPath, err := filepath.Rel(projectRoot, filepath.Dir(path))
-		if err != nil {
-			return nil
-		}
-		if relPath == "." {
-			relPath = ""
-		}
+			relPath, err := filepath.Rel(projectRoot, filepath.Dir(path))
+			if err != nil {
+				return nil
+			}
+			if relPath == "." {
+				relPath = ""
+			}
 
-		m.nestedMatchers = append(m.nestedMatchers, nestedMatcher{
-			matcher: gi,
-			baseDir: relPath,
-		})
+			gm.baseDir = relPath
+			m.grepaiMatchers = append(m.grepaiMatchers, gm)
+			if hasNegations {
+				m.hasGrepaiNegations = true
+			}
+		}
 
 		return nil
 	})
@@ -125,44 +157,184 @@ func NewIgnoreMatcher(projectRoot string, extraIgnore []string, externalGitignor
 }
 
 func (m *IgnoreMatcher) ShouldIgnore(path string) bool {
-	// Normalize path separators for cross-platform compatibility
 	normalizedPath := filepath.ToSlash(path)
 
-	// Check extra directories first (exact match for efficiency)
-	base := filepath.Base(path)
+	// Phase 1: Check if .grepaiignore has an opinion
+	result, hasOpinion, grepaiBaseDir := m.evalGrepaiIgnore(normalizedPath)
+	if hasOpinion {
+		if result {
+			return true // .grepaiignore says ignore → always respect
+		}
+		// .grepaiignore says don't ignore (negation).
+		// Only override .gitignore at the same level or shallower.
+		// If a deeper .gitignore ignores this path, respect the .gitignore.
+		if ignored, gitBaseDir := m.evalGitIgnoreWithLevel(normalizedPath); ignored && len(gitBaseDir) > len(grepaiBaseDir) {
+			return true // Deeper .gitignore wins over shallower .grepaiignore
+		}
+		return false
+	}
+
+	// Phase 2: No .grepaiignore opinion, delegate to .gitignore + extra patterns
+	return m.evalGitIgnore(normalizedPath)
+}
+
+// ShouldSkipDir determines if a directory can be skipped entirely via filepath.SkipDir.
+// If .grepaiignore has negation patterns, we must descend into ignored directories
+// because individual files inside may be re-included.
+func (m *IgnoreMatcher) ShouldSkipDir(path string) bool {
+	if !m.ShouldIgnore(path) {
+		return false // Not ignored, don't skip
+	}
+
+	normalizedPath := filepath.ToSlash(path)
+
+	// If .grepaiignore explicitly says to ignore this dir → safe to skip
+	if result, hasOpinion, _ := m.evalGrepaiIgnore(normalizedPath); hasOpinion {
+		return result
+	}
+
+	// Ignored by gitignore/extra patterns. If no negations in any .grepaiignore → safe to skip
+	if !m.hasGrepaiNegations {
+		return true
+	}
+
+	// There are negation patterns: files inside might be re-included, don't skip
+	return false
+}
+
+// evalGrepaiIgnore checks .grepaiignore matchers for the path.
+// Returns (result, hasOpinion, baseDir) where baseDir is the directory level of the matching .grepaiignore.
+// The most specific matcher (longest baseDir) wins.
+func (m *IgnoreMatcher) evalGrepaiIgnore(normalizedPath string) (bool, bool, string) {
+	var bestMatch *grepaiMatcher
+	bestBaseLen := -1
+
+	for i := range m.grepaiMatchers {
+		gm := &m.grepaiMatchers[i]
+		relPath := matcherRelPath(normalizedPath, gm.baseDir)
+		if relPath == "" && gm.baseDir != "" {
+			continue // This matcher doesn't apply to this path
+		}
+
+		// Check if the "any" matcher detects this path (any pattern matches, positive or negative)
+		if gm.any.MatchesPath(relPath) || gm.any.MatchesPath(relPath+"/") {
+			if len(gm.baseDir) > bestBaseLen {
+				bestMatch = gm
+				bestBaseLen = len(gm.baseDir)
+			}
+		}
+	}
+
+	if bestMatch == nil {
+		return false, false, "" // No .grepaiignore has an opinion
+	}
+
+	relPath := matcherRelPath(normalizedPath, bestMatch.baseDir)
+	// The full matcher (with negations) gives the final answer.
+	// Check both with and without trailing slash. The trailing-slash variant
+	// is more specific (matches directory patterns), so if it says "not ignored"
+	// (negation matched), that takes precedence.
+	matchPlain := bestMatch.full.MatchesPath(relPath)
+	matchSlash := bestMatch.full.MatchesPath(relPath + "/")
+	if matchPlain && !matchSlash {
+		// The trailing-slash check negated the match → not ignored
+		return false, true, bestMatch.baseDir
+	}
+	return matchPlain || matchSlash, true, bestMatch.baseDir
+}
+
+// evalGitIgnore checks extra dirs and .gitignore matchers (original ShouldIgnore logic).
+func (m *IgnoreMatcher) evalGitIgnore(normalizedPath string) bool {
+	ignored, _ := m.evalGitIgnoreWithLevel(normalizedPath)
+	return ignored
+}
+
+// evalGitIgnoreWithLevel checks .gitignore/extra patterns and returns the deepest matching level.
+func (m *IgnoreMatcher) evalGitIgnoreWithLevel(normalizedPath string) (bool, string) {
+	found := false
+	deepestBaseDir := ""
+
+	// Check extra directories (root-level, baseDir="")
+	base := filepath.Base(normalizedPath)
 	for _, dir := range m.extraDirs {
 		if base == dir {
-			return true
+			found = true
+			break
 		}
 	}
 
-	// Check nested gitignore patterns
+	// Check nested gitignore patterns, find the deepest match
 	for _, nm := range m.nestedMatchers {
-		// Determine the relative path from this matcher's base directory
-		var relPath string
-		if nm.baseDir == "" {
-			// Root-level matcher applies to all paths
-			relPath = normalizedPath
-		} else {
-			// Nested matcher only applies to paths within its directory
-			normalizedBase := filepath.ToSlash(nm.baseDir)
-			if !strings.HasPrefix(normalizedPath, normalizedBase+"/") && normalizedPath != normalizedBase {
-				continue // This matcher doesn't apply to this path
-			}
-			// Get path relative to the matcher's base directory
-			relPath = strings.TrimPrefix(normalizedPath, normalizedBase+"/")
+		relPath := matcherRelPath(normalizedPath, nm.baseDir)
+		if relPath == "" && nm.baseDir != "" {
+			continue
 		}
 
-		if nm.matcher.MatchesPath(relPath) {
-			return true
-		}
-		// Also check with trailing slash to match directory patterns like "build/"
-		if nm.matcher.MatchesPath(relPath + "/") {
-			return true
+		if nm.matcher.MatchesPath(relPath) || nm.matcher.MatchesPath(relPath+"/") {
+			if !found || len(nm.baseDir) > len(deepestBaseDir) {
+				deepestBaseDir = nm.baseDir
+				found = true
+			}
 		}
 	}
 
-	return false
+	return found, deepestBaseDir
+}
+
+// matcherRelPath computes the path relative to a matcher's base directory.
+// Returns empty string if the path is outside the matcher's scope (when baseDir is non-empty).
+func matcherRelPath(normalizedPath, baseDir string) string {
+	if baseDir == "" {
+		return normalizedPath
+	}
+	normalizedBase := filepath.ToSlash(baseDir)
+	if normalizedPath == normalizedBase {
+		return "."
+	}
+	if strings.HasPrefix(normalizedPath, normalizedBase+"/") {
+		return strings.TrimPrefix(normalizedPath, normalizedBase+"/")
+	}
+	return "" // Path is outside this matcher's scope
+}
+
+// compileGrepaiIgnoreFile reads a .grepaiignore file and compiles two matchers:
+// - full: uses original patterns (with negations) for the actual decision
+// - any: uses all patterns converted to positive for detecting if the file has an opinion
+// Also returns whether the file contains any negation patterns.
+func compileGrepaiIgnoreFile(path string) (grepaiMatcher, bool, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return grepaiMatcher{}, false, err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	fullLines := make([]string, 0, len(lines))
+	anyLines := make([]string, 0, len(lines))
+	hasNegations := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		fullLines = append(fullLines, trimmed)
+
+		if strings.HasPrefix(trimmed, "!") {
+			hasNegations = true
+			// Strip the ! to make it a positive match for detection
+			anyLines = append(anyLines, strings.TrimPrefix(trimmed, "!"))
+		} else {
+			anyLines = append(anyLines, trimmed)
+		}
+	}
+
+	fullMatcher := ignore.CompileIgnoreLines(fullLines...)
+	anyMatcher := ignore.CompileIgnoreLines(anyLines...)
+
+	return grepaiMatcher{
+		full: fullMatcher,
+		any:  anyMatcher,
+	}, hasNegations, nil
 }
 
 // AddToGitignore appends a pattern to .gitignore if not already present

--- a/indexer/scanner.go
+++ b/indexer/scanner.go
@@ -139,15 +139,16 @@ func (s *Scanner) ScanMetadata() ([]FileMeta, []string, error) {
 			return nil
 		}
 
-		// Skip ignored paths
-		if s.ignore.ShouldIgnore(relPath) {
-			if d.IsDir() {
+		// Handle directories: use ShouldSkipDir to respect .grepaiignore negations
+		if d.IsDir() {
+			if s.ignore.ShouldSkipDir(relPath) {
 				return filepath.SkipDir
 			}
-			return nil
+			return nil // Descend into the directory
 		}
 
-		if d.IsDir() {
+		// Skip ignored files
+		if s.ignore.ShouldIgnore(relPath) {
 			return nil
 		}
 
@@ -200,15 +201,16 @@ func (s *Scanner) Scan() ([]FileInfo, []string, error) {
 			return nil
 		}
 
-		// Skip ignored paths
-		if s.ignore.ShouldIgnore(relPath) {
-			if d.IsDir() {
+		// Handle directories: use ShouldSkipDir to respect .grepaiignore negations
+		if d.IsDir() {
+			if s.ignore.ShouldSkipDir(relPath) {
 				return filepath.SkipDir
 			}
-			return nil
+			return nil // Descend into the directory
 		}
 
-		if d.IsDir() {
+		// Skip ignored files
+		if s.ignore.ShouldIgnore(relPath) {
 			return nil
 		}
 


### PR DESCRIPTION
## Summary

- Add `.grepaiignore` file support to override `.gitignore` rules for grepai indexing
- Support negation patterns (`!`) to re-include files/directories excluded by `.gitignore`
- Respect directory-level precedence: deeper `.gitignore` wins over shallower `.grepaiignore` negations, same-level `.grepaiignore` always overrides same-level `.gitignore`
- Update scanner and watcher to use `ShouldSkipDir` to prevent premature directory pruning when negation patterns exist

Closes #107

## Test plan

- [x] `TestGrepaiIgnore_BasicExclusion` — extra exclusion patterns via `.grepaiignore`
- [x] `TestGrepaiIgnore_Negation` — re-include directories excluded by `.gitignore`
- [x] `TestGrepaiIgnore_SelectiveNegation` — partial re-inclusion (`vendor/important/` only)
- [x] `TestGrepaiIgnore_OverridesExtraPatterns` — negation overrides config extra patterns
- [x] `TestGrepaiIgnore_Nested` — nested `.grepaiignore` scoped to its directory
- [x] `TestGrepaiIgnore_NotPresent` — no `.grepaiignore` = no behavior change
- [x] `TestShouldSkipDir_WithNegation` — directory traversal respects negation patterns
- [x] `TestScanner_RespectsGrepaiIgnoreNegation` — end-to-end scanner test
- [x] `TestGrepaiIgnore_DoesNotOverrideNestedGitignore` — deeper `.gitignore` wins over shallower `.grepaiignore`
- [x] `TestGrepaiIgnore_OverridesSameLevelGitignore` — same-level override works
- [x] `TestGrepaiIgnore_NestedOverridesNestedGitignore` — nested same-level override works
- [x] All CI checks passing (`make pre-commit` green)
- [x] CHANGELOG.md updated