### PR TITLE
docs: add agent integration step to quickstart

### DIFF
--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -102,12 +102,11 @@ func handleAPIError(w http.ResponseWriter, err error) {
 
 ## 5. Connect to Your AI Agent
 
-grepai is designed to work with AI coding agents. After indexing, connect it to your agent via [MCP](/grepai/mcp/) (recommended) or the [subagent](/grepai/subagent/) integration:
+Your index is built, but your AI agent doesn't know it exists yet. The recommended way to connect grepai is through **[MCP](/grepai/mcp/)**, which exposes search, trace, and index status as native tools for any MCP-compatible agent.
 
-- **[MCP Integration](/grepai/mcp/)** — Exposes grepai as native tools (search, trace, index status) to any MCP-compatible agent
-- **[Claude Code Subagent](/grepai/subagent/)** — Adds a specialized exploration agent that uses grepai for code discovery
+If your agent doesn't support MCP, `grepai agent-setup` is an alternative that appends CLI usage instructions to agent config files (CLAUDE.md, .cursorrules, etc.) so the agent calls grepai through the command line. This is not needed if you use MCP.
 
-Without this step, your index is built but your agent doesn't know it exists.
+For Claude Code users, there is also an optional **[subagent](/grepai/subagent/)** that gives exploration agents grepai access in their isolated context.
 
 ## Tips for Better Searches
 


### PR DESCRIPTION
## Problem

The quickstart guide walks users through `init` → `watch` → `search` → `status`, but never tells them how to connect grepai to their AI agent. The agent integration pages (MCP, subagent) exist but are only discoverable by browsing the sidebar or finding the `agent-setup` command reference link buried in "Next Steps."

This means users finish the quickstart with a working index but an agent that doesn't know grepai exists — then wonder what they missed.

## Change

Adds **Step 5: Connect to Your AI Agent** to the quickstart with clear guidance on the three integration paths:

- **MCP** — recommended, exposes native tools to any MCP-compatible agent
- **`agent-setup`** — CLI-based alternative that appends usage instructions to agent config files (CLAUDE.md, .cursorrules, etc.), explicitly noted as not needed when using MCP
- **Subagent** — optional Claude Code integration, mentioned lightly with a link to its dedicated page

Also removes the old `agent-setup` command reference link from "Next Steps" since step 5 covers agent integration with better context.

## Before → After

**Before:** Quickstart ends at step 4 (check index status). Agent integration is a "Next Steps" link to the `agent-setup` command reference.

**After:** Step 5 makes it clear there's one more thing to do, distinguishes between the integration options, and helps users pick the right one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)