### PR TITLE
Fix OpenAI init model handling and config defaults

### DIFF
--- a/cli/init.go
+++ b/cli/init.go
@@ -40,7 +40,7 @@ This command will:
 
 func init() {
 	initCmd.Flags().StringVarP(&initProvider, "provider", "p", "", "Embedding provider (ollama, lmstudio, openai, synthetic, or openrouter)")
-	initCmd.Flags().StringVarP(&initModel, "model", "m", "", "Embedding model (for openrouter: text-embedding-3-small, text-embedding-3-large, qwen3-embedding-8b)")
+	initCmd.Flags().StringVarP(&initModel, "model", "m", "", "Embedding model (for openai/openrouter: text-embedding-3-small, text-embedding-3-large; openrouter also supports qwen3-embedding-8b)")
 	initCmd.Flags().StringVarP(&initBackend, "backend", "b", "", "Storage backend (gob, postgres, or qdrant)")
 	initCmd.Flags().BoolVar(&initNonInteractive, "yes", false, "Use defaults without prompting")
 	initCmd.Flags().BoolVar(&initInherit, "inherit", false, "Inherit configuration from main worktree (for git worktrees)")
@@ -143,8 +143,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 				cfg.Embedder.Dimensions = &dim
 			case "3", "openai":
 				cfg.Embedder.Provider = "openai"
-				cfg.Embedder.Model = "text-embedding-3-small"
+				cfg.Embedder.Model = config.DefaultOpenAIEmbeddingModel
 				cfg.Embedder.Endpoint = "https://api.openai.com/v1"
+				cfg.Embedder.Parallelism = config.DefaultOpenAIParallelism
 				// OpenAI: leave Dimensions nil to use model's native dimensions
 			case "4", "synthetic":
 				cfg.Embedder.Provider = "synthetic"
@@ -194,8 +195,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 				dim := lmStudioEmbeddingDimensions
 				cfg.Embedder.Dimensions = &dim
 			case "openai":
-				cfg.Embedder.Model = "text-embedding-3-small"
+				cfg.Embedder.Model = resolveInitModel(initProvider, initModel)
 				cfg.Embedder.Endpoint = "https://api.openai.com/v1"
+				cfg.Embedder.Parallelism = config.DefaultOpenAIParallelism
 				// OpenAI: leave Dimensions nil to use model's native dimensions
 			case "synthetic":
 				cfg.Embedder.Model = "hf:nomic-ai/nomic-embed-text-v1.5"
@@ -203,7 +205,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 				dim := 768
 				cfg.Embedder.Dimensions = &dim
 			case "openrouter":
-				cfg.Embedder.Model = "openai/text-embedding-3-small"
+				cfg.Embedder.Model = resolveInitModel(initProvider, initModel)
 				cfg.Embedder.Endpoint = "https://openrouter.ai/api/v1"
 				// OpenRouter: leave Dimensions nil to use model's native dimensions
 			}
@@ -280,9 +282,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 				dim := lmStudioEmbeddingDimensions
 				cfg.Embedder.Dimensions = &dim
 			case "openai":
-				cfg.Embedder.Model = "text-embedding-3-small"
+				cfg.Embedder.Model = resolveInitModel(initProvider, initModel)
 				cfg.Embedder.Endpoint = "https://api.openai.com/v1"
 				cfg.Embedder.Dimensions = nil
+				cfg.Embedder.Parallelism = config.DefaultOpenAIParallelism
 			case "synthetic":
 				cfg.Embedder.Model = "hf:nomic-ai/nomic-embed-text-v1.5"
 				cfg.Embedder.Endpoint = "https://api.synthetic.new/openai/v1"
@@ -291,15 +294,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 			case "openrouter":
 				cfg.Embedder.Endpoint = "https://openrouter.ai/api/v1"
 				cfg.Embedder.Dimensions = nil
-				// Use provided model flag or default
-				switch initModel {
-				case "text-embedding-3-large":
-					cfg.Embedder.Model = "openai/text-embedding-3-large"
-				case "qwen3-embedding-8b":
-					cfg.Embedder.Model = "qwen/qwen3-embedding-8b"
-				default:
-					cfg.Embedder.Model = "openai/text-embedding-3-small"
-				}
+				cfg.Embedder.Model = resolveInitModel(initProvider, initModel)
 			}
 		}
 		if initBackend != "" {
@@ -352,4 +347,28 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 func shouldPromptInheritChoice(shouldInherit, nonInteractive, uiMode bool) bool {
 	return !shouldInherit && !nonInteractive && !uiMode
+}
+
+func resolveInitModel(provider, requestedModel string) string {
+	requestedModel = strings.TrimSpace(requestedModel)
+	switch provider {
+	case "openai":
+		if requestedModel != "" {
+			return requestedModel
+		}
+		return config.DefaultOpenAIEmbeddingModel
+	case "openrouter":
+		switch requestedModel {
+		case "text-embedding-3-large":
+			return config.OpenRouterEmbeddingModelLarge
+		case "qwen3-embedding-8b":
+			return config.OpenRouterEmbeddingModelQwen8B
+		case "text-embedding-3-small", "":
+			return config.DefaultOpenRouterEmbeddingModel
+		default:
+			return requestedModel
+		}
+	default:
+		return requestedModel
+	}
 }

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/yoanbernabeu/grepai/config"
+)
+
+func withInitTestState(t *testing.T, dir string, configure func()) {
+	t.Helper()
+
+	prevCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir(%s): %v", dir, err)
+	}
+
+	prevProvider := initProvider
+	prevModel := initModel
+	prevBackend := initBackend
+	prevNonInteractive := initNonInteractive
+	prevInherit := initInherit
+	prevUI := initUI
+
+	initProvider = ""
+	initModel = ""
+	initBackend = ""
+	initNonInteractive = false
+	initInherit = false
+	initUI = false
+	configure()
+
+	t.Cleanup(func() {
+		_ = os.Chdir(prevCwd)
+		initProvider = prevProvider
+		initModel = prevModel
+		initBackend = prevBackend
+		initNonInteractive = prevNonInteractive
+		initInherit = prevInherit
+		initUI = prevUI
+	})
+}
+
+func TestRunInit_OpenAIExplicitModelHonored(t *testing.T) {
+	tmpDir := t.TempDir()
+	withInitTestState(t, tmpDir, func() {
+		initProvider = "openai"
+		initModel = "text-embedding-3-large"
+		initBackend = "gob"
+		initNonInteractive = true
+	})
+
+	if err := runInit(nil, nil); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	cfg, err := config.Load(tmpDir)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.Embedder.Model != "text-embedding-3-large" {
+		t.Fatalf("model = %q, want text-embedding-3-large", cfg.Embedder.Model)
+	}
+	if cfg.Embedder.Parallelism != config.DefaultOpenAIParallelism {
+		t.Fatalf("parallelism = %d, want %d", cfg.Embedder.Parallelism, config.DefaultOpenAIParallelism)
+	}
+	if cfg.Embedder.GetDimensions() != config.DefaultOpenAILargeDimensions {
+		t.Fatalf("dimensions = %d, want %d", cfg.Embedder.GetDimensions(), config.DefaultOpenAILargeDimensions)
+	}
+}
+
+func TestRunInit_OpenAIDefaultsToOpenAISmallModel(t *testing.T) {
+	tmpDir := t.TempDir()
+	withInitTestState(t, tmpDir, func() {
+		initProvider = "openai"
+		initBackend = "gob"
+		initNonInteractive = true
+	})
+
+	if err := runInit(nil, nil); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	cfg, err := config.Load(tmpDir)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.Embedder.Model != config.DefaultOpenAIEmbeddingModel {
+		t.Fatalf("model = %q, want %q", cfg.Embedder.Model, config.DefaultOpenAIEmbeddingModel)
+	}
+	if cfg.Embedder.Parallelism != config.DefaultOpenAIParallelism {
+		t.Fatalf("parallelism = %d, want %d", cfg.Embedder.Parallelism, config.DefaultOpenAIParallelism)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,9 @@ const (
 	DefaultOpenAIEmbeddingModel     = "text-embedding-3-small"
 	DefaultSyntheticEmbeddingModel  = "hf:nomic-ai/nomic-embed-text-v1.5"
 	DefaultOpenRouterEmbeddingModel = "openai/text-embedding-3-small"
+	OpenAIEmbeddingModelLarge       = "text-embedding-3-large"
+	OpenRouterEmbeddingModelLarge   = "openai/text-embedding-3-large"
+	OpenRouterEmbeddingModelQwen8B  = "qwen/qwen3-embedding-8b"
 
 	DefaultOllamaEndpoint     = "http://localhost:11434"
 	DefaultLMStudioEndpoint   = "http://127.0.0.1:1234"
@@ -33,6 +36,9 @@ const (
 
 	DefaultLocalEmbeddingDimensions = 768
 	DefaultOpenAIDimensions         = 1536
+	DefaultOpenAILargeDimensions    = 3072
+	DefaultQwen8BDimensions         = 4096
+	DefaultOpenAIParallelism        = 4
 
 	DefaultPostgresDSN    = "postgres://localhost:5432/grepai"
 	DefaultQdrantEndpoint = "localhost"
@@ -110,7 +116,14 @@ func (e *EmbedderConfig) GetDimensions() int {
 	}
 	switch e.Provider {
 	case "openai", "openrouter":
-		return DefaultOpenAIDimensions
+		switch strings.TrimSpace(e.Model) {
+		case OpenAIEmbeddingModelLarge, OpenRouterEmbeddingModelLarge:
+			return DefaultOpenAILargeDimensions
+		case OpenRouterEmbeddingModelQwen8B, "qwen3-embedding-8b":
+			return DefaultQwen8BDimensions
+		default:
+			return DefaultOpenAIDimensions
+		}
 	default:
 		return DefaultLocalEmbeddingDimensions
 	}
@@ -143,10 +156,11 @@ func DefaultEmbedderForProvider(provider string) EmbedderConfig {
 		}
 	case "openai":
 		return EmbedderConfig{
-			Provider:   "openai",
-			Model:      DefaultOpenAIEmbeddingModel,
-			Endpoint:   DefaultOpenAIEndpoint,
-			Dimensions: nil,
+			Provider:    "openai",
+			Model:       DefaultOpenAIEmbeddingModel,
+			Endpoint:    DefaultOpenAIEndpoint,
+			Dimensions:  nil,
+			Parallelism: DefaultOpenAIParallelism,
 		}
 	case "ollama":
 		fallthrough

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -83,6 +83,9 @@ func TestDefaultEmbedderForProvider(t *testing.T) {
 	if openai.Dimensions != nil {
 		t.Fatalf("openai dimensions should be nil, got %v", openai.Dimensions)
 	}
+	if openai.Parallelism != DefaultOpenAIParallelism {
+		t.Fatalf("openai parallelism = %d, want %d", openai.Parallelism, DefaultOpenAIParallelism)
+	}
 }
 
 func TestDefaultStoreForBackend(t *testing.T) {
@@ -472,6 +475,19 @@ store:
 `,
 			expectedNil:        true,
 			expectedDimensions: 1536, // GetDimensions() returns default
+		},
+		{
+			name: "openai large without dimensions infers large dimensions",
+			configYAML: `version: 1
+embedder:
+  provider: openai
+  model: text-embedding-3-large
+  api_key: sk-test
+store:
+  backend: gob
+`,
+			expectedNil:        true,
+			expectedDimensions: 3072,
 		},
 		{
 			name: "openai with explicit dimensions sets pointer",


### PR DESCRIPTION
## Summary
- honor explicit `grepai init --provider openai --model ...` requests instead of always writing the small model
- preserve the documented OpenAI `parallelism: 4` default in generated configs
- infer embedding dimensions from the selected OpenAI/OpenRouter model when dimensions are omitted

## Details
`init` previously hard-coded `text-embedding-3-small` for OpenAI in the non-interactive path, so `--model text-embedding-3-large` was ignored. The config layer also treated omitted dimensions as `1536` for all OpenAI/OpenRouter models, which is incorrect for `text-embedding-3-large` and `qwen3-embedding-8b`.

This patch keeps the upstream default model as small, but fixes three bugs:
- explicit `--model` is respected for OpenAI and OpenRouter init flows
- default OpenAI config objects and generated init configs include `parallelism: 4`
- `GetDimensions()` returns `3072` for `text-embedding-3-large` and `4096` for `qwen3-embedding-8b` when dimensions are omitted

## Validation
- `go test -v -race ./...`
- `go build -o /Users/gary/AI/vendor/grepai/bin/grepai ./cmd/grepai`

One store test remains environment-skipped by the upstream suite when no PostgreSQL DSN is configured.
