### PR TITLE
Fix OpenAI workspace create defaults

### DIFF
--- a/cli/workspace.go
+++ b/cli/workspace.go
@@ -23,6 +23,8 @@ var (
 	workspaceStatusUIRunner   = runWorkspaceStatusUI
 )
 
+const workspaceCreateOpenAIParallelism = 4
+
 var workspaceCmd = &cobra.Command{
 	Use:   "workspace",
 	Short: "Manage multi-project workspaces",
@@ -255,9 +257,9 @@ func buildWorkspaceFromFlags(name, backend, provider, model, dsn, endpoint, qdra
 	if model == "" {
 		switch provider {
 		case "openai":
-			model = "text-embedding-3-small"
+			model = config.DefaultOpenAIEmbeddingModel
 		default:
-			model = "nomic-embed-text"
+			model = config.DefaultOllamaEmbeddingModel
 		}
 	}
 
@@ -291,23 +293,24 @@ func buildWorkspaceFromFlags(name, backend, provider, model, dsn, endpoint, qdra
 	switch provider {
 	case "ollama":
 		if endpoint == "" {
-			endpoint = "http://localhost:11434"
+			endpoint = config.DefaultOllamaEndpoint
 		}
 		embedderConfig.Endpoint = endpoint
-		dim := 768
+		dim := config.DefaultLocalEmbeddingDimensions
 		embedderConfig.Dimensions = &dim
 	case "lmstudio":
 		if endpoint == "" {
-			endpoint = "http://127.0.0.1:1234"
+			endpoint = config.DefaultLMStudioEndpoint
 		}
 		embedderConfig.Endpoint = endpoint
-		dim := 768
+		dim := config.DefaultLocalEmbeddingDimensions
 		embedderConfig.Dimensions = &dim
 	case "openai":
 		if endpoint == "" {
-			endpoint = "https://api.openai.com/v1"
+			endpoint = config.DefaultOpenAIEndpoint
 		}
 		embedderConfig.Endpoint = endpoint
+		embedderConfig.Parallelism = workspaceCreateOpenAIParallelism
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s (use ollama, openai, or lmstudio)", provider)
 	}
@@ -535,14 +538,15 @@ func createWorkspaceInteractive(workspaceName string) (*config.Workspace, error)
 		fmt.Print("OpenAI API Key: ")
 		apiKey, _ := reader.ReadString('\n')
 		embedderConfig.APIKey = strings.TrimSpace(apiKey)
-		fmt.Print("Model [text-embedding-3-small]: ")
+		fmt.Printf("Model [%s]: ", config.DefaultOpenAIEmbeddingModel)
 		model, _ := reader.ReadString('\n')
 		model = strings.TrimSpace(model)
 		if model == "" {
-			model = "text-embedding-3-small"
+			model = config.DefaultOpenAIEmbeddingModel
 		}
 		embedderConfig.Model = model
-		embedderConfig.Endpoint = "https://api.openai.com/v1"
+		embedderConfig.Endpoint = config.DefaultOpenAIEndpoint
+		embedderConfig.Parallelism = workspaceCreateOpenAIParallelism
 	case "3":
 		embedderConfig.Provider = "lmstudio"
 		fmt.Print("LM Studio endpoint [http://127.0.0.1:1234]: ")

--- a/cli/workspace_create_test.go
+++ b/cli/workspace_create_test.go
@@ -65,6 +65,36 @@ func TestCreateWorkspaceNonInteractive(t *testing.T) {
 		if ws.Embedder.Provider != "openai" {
 			t.Errorf("expected openai provider, got %s", ws.Embedder.Provider)
 		}
+		if ws.Embedder.Model != "text-embedding-3-small" {
+			t.Errorf("expected text-embedding-3-small model, got %s", ws.Embedder.Model)
+		}
+		if ws.Embedder.Endpoint != config.DefaultOpenAIEndpoint {
+			t.Errorf("expected OpenAI endpoint %s, got %s", config.DefaultOpenAIEndpoint, ws.Embedder.Endpoint)
+		}
+		if ws.Embedder.Parallelism != workspaceCreateOpenAIParallelism {
+			t.Errorf("expected OpenAI parallelism %d, got %d", workspaceCreateOpenAIParallelism, ws.Embedder.Parallelism)
+		}
+	})
+
+	t.Run("flags_postgres_openai_default_model_and_parallelism", func(t *testing.T) {
+		tmpDir, _ := os.MkdirTemp("", "grepai-test-cli")
+		defer os.RemoveAll(tmpDir)
+		cleanup := setTestHomeDirCLI(t, tmpDir)
+		defer cleanup()
+
+		ws, err := buildWorkspaceFromFlags("test-ws", "postgres", "openai", "", "postgres://localhost:5432/grepai", "", "", 0, "", false)
+		if err != nil {
+			t.Fatalf("buildWorkspaceFromFlags error: %v", err)
+		}
+		if ws.Embedder.Model != config.DefaultOpenAIEmbeddingModel {
+			t.Errorf("expected default OpenAI model %s, got %s", config.DefaultOpenAIEmbeddingModel, ws.Embedder.Model)
+		}
+		if ws.Embedder.Endpoint != config.DefaultOpenAIEndpoint {
+			t.Errorf("expected default OpenAI endpoint %s, got %s", config.DefaultOpenAIEndpoint, ws.Embedder.Endpoint)
+		}
+		if ws.Embedder.Parallelism != workspaceCreateOpenAIParallelism {
+			t.Errorf("expected OpenAI parallelism %d, got %d", workspaceCreateOpenAIParallelism, ws.Embedder.Parallelism)
+		}
 	})
 
 	t.Run("yes_defaults", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix OpenAI `workspace create` so generated workspaces write `parallelism: 4` instead of `0`
- reuse shared config defaults for OpenAI/Ollama/LM Studio endpoints and default models in workspace creation paths
- keep the OpenAI workspace default model as `text-embedding-3-small`

## Details
This PR is intentionally separate from #181.

`grepai workspace create` had its own defaulting logic and did not set `embedder.parallelism` for OpenAI, so generated `~/.grepai/workspace.yaml` entries contained `parallelism: 0`. The OpenAI default model remains the current upstream product default (`text-embedding-3-small`); this change only fixes parity and explicitness for workspace config generation.

The patch:
- sets `parallelism` to `4` for OpenAI workspace creation in both the shared flag path and interactive path
- reuses shared config constants where available instead of repeating string literals
- adds focused tests for OpenAI workspace creation defaults

## Validation
- `go test ./cli -run 'TestCreateWorkspaceNonInteractive|TestIntegration_WorkspaceCreateAndMCPResolve'`
- `go build -o /Users/gary/AI/vendor/grepai/bin/grepai ./cmd/grepai`
- isolated runtime check: `grepai workspace create demo --backend postgres --provider openai --yes` now writes `parallelism: 4` while keeping `model: text-embedding-3-small`
