### PR TITLE
feat(search): add configurable file-level deduplication

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,12 @@ type UpdateConfig struct {
 type SearchConfig struct {
 	Boost  BoostConfig  `yaml:"boost"`
 	Hybrid HybridConfig `yaml:"hybrid"`
+	Dedup  DedupConfig  `yaml:"dedup"`
+}
+
+// DedupConfig controls file-level deduplication of search results.
+type DedupConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 type HybridConfig struct {
@@ -300,6 +306,9 @@ func DefaultConfig() *Config {
 			RPGMaxDirtyFilesPerBatch:    DefaultWatchRPGMaxDirtyFilesPerBatch,
 		},
 		Search: SearchConfig{
+			Dedup: DedupConfig{
+				Enabled: true,
+			},
 			Hybrid: HybridConfig{
 				Enabled: false,
 				K:       60,

--- a/search/dedup.go
+++ b/search/dedup.go
@@ -1,0 +1,17 @@
+package search
+
+import "github.com/yoanbernabeu/grepai/store"
+
+// DeduplicateByFile keeps only the highest-scoring chunk per file path.
+func DeduplicateByFile(results []store.SearchResult) []store.SearchResult {
+	seen := make(map[string]bool, len(results))
+	deduped := make([]store.SearchResult, 0, len(results))
+	for _, r := range results {
+		if seen[r.Chunk.FilePath] {
+			continue
+		}
+		seen[r.Chunk.FilePath] = true
+		deduped = append(deduped, r)
+	}
+	return deduped
+}

--- a/search/dedup_test.go
+++ b/search/dedup_test.go
@@ -1,0 +1,62 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/yoanbernabeu/grepai/store"
+)
+
+func TestDeduplicateByFile(t *testing.T) {
+	results := []store.SearchResult{
+		{Chunk: store.Chunk{ID: "a_0", FilePath: "a.go"}, Score: 0.9},
+		{Chunk: store.Chunk{ID: "b_0", FilePath: "b.go"}, Score: 0.8},
+		{Chunk: store.Chunk{ID: "a_1", FilePath: "a.go"}, Score: 0.7},
+		{Chunk: store.Chunk{ID: "c_0", FilePath: "c.go"}, Score: 0.6},
+		{Chunk: store.Chunk{ID: "b_1", FilePath: "b.go"}, Score: 0.5},
+	}
+
+	deduped := DeduplicateByFile(results)
+
+	if len(deduped) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(deduped))
+	}
+
+	expected := []struct {
+		id    string
+		score float32
+	}{
+		{"a_0", 0.9},
+		{"b_0", 0.8},
+		{"c_0", 0.6},
+	}
+
+	for i, want := range expected {
+		if deduped[i].Chunk.ID != want.id {
+			t.Errorf("result[%d]: expected ID %q, got %q", i, want.id, deduped[i].Chunk.ID)
+		}
+		if deduped[i].Score != want.score {
+			t.Errorf("result[%d]: expected score %v, got %v", i, want.score, deduped[i].Score)
+		}
+	}
+}
+
+func TestDeduplicateByFile_Empty(t *testing.T) {
+	deduped := DeduplicateByFile(nil)
+	if len(deduped) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(deduped))
+	}
+}
+
+func TestDeduplicateByFile_AllUnique(t *testing.T) {
+	results := []store.SearchResult{
+		{Chunk: store.Chunk{ID: "a_0", FilePath: "a.go"}, Score: 0.9},
+		{Chunk: store.Chunk{ID: "b_0", FilePath: "b.go"}, Score: 0.8},
+		{Chunk: store.Chunk{ID: "c_0", FilePath: "c.go"}, Score: 0.7},
+	}
+
+	deduped := DeduplicateByFile(results)
+
+	if len(deduped) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(deduped))
+	}
+}

--- a/search/search.go
+++ b/search/search.go
@@ -13,6 +13,7 @@ type Searcher struct {
 	embedder  embedder.Embedder
 	boostCfg  config.BoostConfig
 	hybridCfg config.HybridConfig
+	dedupCfg  config.DedupConfig
 }
 
 func NewSearcher(st store.VectorStore, emb embedder.Embedder, searchCfg config.SearchConfig) *Searcher {
@@ -21,26 +22,27 @@ func NewSearcher(st store.VectorStore, emb embedder.Embedder, searchCfg config.S
 		embedder:  emb,
 		boostCfg:  searchCfg.Boost,
 		hybridCfg: searchCfg.Hybrid,
+		dedupCfg:  searchCfg.Dedup,
 	}
 }
 
 func (s *Searcher) Search(ctx context.Context, query string, limit int, pathPrefix string) ([]store.SearchResult, error) {
-	// Embed the query
 	queryVector, err := s.embedder.Embed(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 
-	// Fetch more results to allow re-ranking
-	fetchLimit := limit * 2
+	fetchMultiplier := 2
+	if s.dedupCfg.Enabled {
+		fetchMultiplier = 4
+	}
+	fetchLimit := limit * fetchMultiplier
 
 	var results []store.SearchResult
 
 	if s.hybridCfg.Enabled {
-		// Hybrid search: combine vector + text search with RRF
 		results, err = s.hybridSearch(ctx, query, queryVector, fetchLimit, pathPrefix)
 	} else {
-		// Vector-only search
 		results, err = s.store.Search(ctx, queryVector, fetchLimit, store.SearchOptions{PathPrefix: pathPrefix})
 	}
 
@@ -48,10 +50,12 @@ func (s *Searcher) Search(ctx context.Context, query string, limit int, pathPref
 		return nil, err
 	}
 
-	// Apply structural boosting
 	results = ApplyBoost(results, s.boostCfg)
 
-	// Trim to requested limit
+	if s.dedupCfg.Enabled {
+		results = DeduplicateByFile(results)
+	}
+
 	if len(results) > limit {
 		results = results[:limit]
 	}
@@ -61,13 +65,11 @@ func (s *Searcher) Search(ctx context.Context, query string, limit int, pathPref
 
 // hybridSearch combines vector search and text search using RRF.
 func (s *Searcher) hybridSearch(ctx context.Context, query string, queryVector []float32, limit int, pathPrefix string) ([]store.SearchResult, error) {
-	// Vector search
 	vectorResults, err := s.store.Search(ctx, queryVector, limit, store.SearchOptions{PathPrefix: pathPrefix})
 	if err != nil {
 		return nil, err
 	}
 
-	// Text search (get all chunks first)
 	allChunks, err := s.store.GetAllChunks(ctx)
 	if err != nil {
 		return nil, err
@@ -75,10 +77,9 @@ func (s *Searcher) hybridSearch(ctx context.Context, query string, queryVector [
 
 	textResults := TextSearch(ctx, allChunks, query, limit, pathPrefix)
 
-	// Combine with RRF
 	k := s.hybridCfg.K
 	if k <= 0 {
-		k = 60 // default
+		k = 60
 	}
 
 	return ReciprocalRankFusion(k, limit, vectorResults, textResults), nil


### PR DESCRIPTION
## problem

when a search query matches several chunks from the same file, the result list fills up with duplicate file entries. this crowds out results from other relevant files and reduces the effective diversity of the top-N list. in practice, a user who asks for 10 results may receive 4 or 5 entries that all point to the same file, which leaves fewer slots for other files that would otherwise rank highly.

## solution

this PR adds a `search.dedup.enabled` option (default: `true`) that retains only the highest-scoring chunk per file path. deduplication runs after boost scoring, so the best chunk is selected with structural penalties and bonuses already applied.

when dedup is enabled, the internal fetch limit increases from `limit * 2` to `limit * 4` so that enough unique files survive the filter. users can disable it in `config.yaml` if they prefer the original behaviour:

```yaml
search:
  dedup:
    enabled: false
```

## changes

| file | what |
|---|---|
| `config/config.go` | add `DedupConfig` struct, wire it into `SearchConfig`, set the default to `true` |
| `search/search.go` | read the dedup config, scale `fetchLimit` conditionally, call `DeduplicateByFile` when enabled |
| `search/dedup.go` | implement `DeduplicateByFile` (keeps the first occurrence per file path from a pre-sorted slice) |
| `search/dedup_test.go` | unit tests: standard case, empty input, all-unique input |

## test plan

- [x] `go test ./search/` passes (all 20 tests, including 3 new dedup tests)
- [x] `go test ./config/` passes
- [x] `go build ./...` succeeds with no warnings
- [ ] manual verification: run `grepai search <query> --json` and confirm that each file path appears at most once in the output
- [ ] manual verification: set `search.dedup.enabled: false` in `config.yaml` and confirm that duplicate file entries reappear

## note

this branch will remain open for additional work (e.g. wiring dedup into the workspace search path). further commits may follow.