### PR TITLE
fix(qdrant): sanitize Windows path separators in collection names

### DIFF
--- a/store/qdrant.go
+++ b/store/qdrant.go
@@ -107,7 +107,13 @@ func (s *QdrantStore) ensureCollection(ctx context.Context) error {
 }
 
 func sanitizeCollectionName(path string) string {
-	return strings.ReplaceAll(path, "/", "_")
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\\', ':', '/':
+			return '_'
+		}
+		return r
+	}, path)
 }
 
 func SanitizeCollectionName(path string) string {

--- a/store/qdrant_test.go
+++ b/store/qdrant_test.go
@@ -30,6 +30,9 @@ func TestSanitizeCollectionName(t *testing.T) {
 		{"root path", "/", "_"},
 		{"multiple slashes", "///", "___"},
 		{"no slashes", "myproject", "myproject"},
+		{"windows drive path", "C:\\Users\\test\\project", "C__Users_test_project"},
+		{"windows drive colon", "C:", "C_"},
+		{"windows nested path", "C:\\Users\\test\\dev\\grepai", "C__Users_test_dev_grepai"},
 	}
 
 	for _, tt := range tests {
@@ -341,7 +344,7 @@ func TestQdrantStore_StructFields(t *testing.T) {
 	}
 }
 
-// TestQdrantStore_CollectionNameSanitization verifies / replacement with _
+// TestQdrantStore_CollectionNameSanitization verifies / \ : replacement with _
 func TestQdrantStore_CollectionNameSanitization(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -353,6 +356,9 @@ func TestQdrantStore_CollectionNameSanitization(t *testing.T) {
 		{"root path", "/", "_"},
 		{"multiple slashes", "///", "___"},
 		{"no slashes", "myproject", "myproject"},
+		{"windows drive path", "C:\\Users\\test\\project", "C__Users_test_project"},
+		{"windows drive colon", "C:", "C_"},
+		{"windows nested path", "C:\\Users\\test\\dev\\grepai", "C__Users_test_dev_grepai"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Qdrant rejects collection names containing ':' or '\'. On Windows, project root paths include drive letters (e.g. C:\Users\...) which caused collection creation to fail with `collection name cannot contain ':' char`. 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

 * Ran `make build-all`, and manually tested the windows and the linux executable. (2 of the 5 built artifacts, don't have easy access to arm or mac)
 * Ran `make pre-commit`, all good.

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

**Test Configuration:**
- OS: Win11 25H2 | WSL (Ubuntu 22.04.5 LTS)
- Go version: go1.26.1 windows/amd64 | go1.26.1 linux/amd64
- Embedding provider: LMStudio, text-embedding-nomic-embed-text-v1.5

## Checklist

- [x] My code follows the project's code style
- [x] I have run `golangci-lint run` and fixed any issues
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed
- [ ] I have added an entry to CHANGELOG.md (if applicable)
- [x] My changes generate no new warnings
- [x] All new and existing tests pass

## Additional Notes
Did not update any docs, but haven't found any related issues, so I assume everyone assumes Windows + Qdrant just works...

I'm not a golang guy, so asked Claude to do the actual code changes, but tested manually, and both windows and linux version do work.