### PR TITLE
fix(indexer): prevent .gitignore patterns from ignoring root directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Gitignore Root Match**: Fix `.gitignore` pattern `.*/` incorrectly matching the root directory and preventing all files from being indexed (#203)
+
 ## [0.35.0] - 2026-03-16
 
 ### Added

--- a/indexer/gitignore.go
+++ b/indexer/gitignore.go
@@ -157,6 +157,13 @@ func NewIgnoreMatcher(projectRoot string, extraIgnore []string, externalGitignor
 }
 
 func (m *IgnoreMatcher) ShouldIgnore(path string) bool {
+	// The root directory itself ("." from filepath.Rel) must never be ignored.
+	// Patterns like ".*/" would otherwise match "." and cause the entire
+	// directory tree to be skipped.
+	if path == "." {
+		return false
+	}
+
 	normalizedPath := filepath.ToSlash(path)
 
 	// Phase 1: Check if .grepaiignore has an opinion

--- a/indexer/gitignore_test.go
+++ b/indexer/gitignore_test.go
@@ -1058,3 +1058,80 @@ func TestGrepaiIgnore_NestedOverridesNestedGitignore(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldIgnore_RootDotPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// .gitignore with .*/ pattern that matches hidden directories
+	gitignore := `.*/
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(gitignore), 0644); err != nil {
+		t.Fatalf("failed to create .gitignore: %v", err)
+	}
+
+	matcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
+	if err != nil {
+		t.Fatalf("failed to create ignore matcher: %v", err)
+	}
+
+	// The root path "." must never be ignored, even though it starts with a dot
+	if matcher.ShouldIgnore(".") {
+		t.Error("ShouldIgnore(\".\") = true, expected false (root directory must never be ignored)")
+	}
+
+	// Hidden directories should still be ignored
+	if !matcher.ShouldIgnore(".hidden") {
+		t.Error("ShouldIgnore(\".hidden\") = false, expected true")
+	}
+
+	// ShouldSkipDir must also not skip the root
+	if matcher.ShouldSkipDir(".") {
+		t.Error("ShouldSkipDir(\".\") = true, expected false (root directory must never be skipped)")
+	}
+}
+
+func TestScanner_DotStarSlashGitignoreDoesNotBlockAll(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// .gitignore with .*/ — should ignore hidden dirs, not everything
+	gitignore := `.*/
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(gitignore), 0644); err != nil {
+		t.Fatalf("failed to create .gitignore: %v", err)
+	}
+
+	// Create a normal file that should be indexed
+	if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("failed to create main.go: %v", err)
+	}
+
+	// Create a hidden directory with a file that should be ignored
+	hiddenDir := filepath.Join(tmpDir, ".hidden")
+	if err := os.MkdirAll(hiddenDir, 0755); err != nil {
+		t.Fatalf("failed to create .hidden dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hiddenDir, "secret.go"), []byte("package secret\n"), 0644); err != nil {
+		t.Fatalf("failed to create .hidden/secret.go: %v", err)
+	}
+
+	matcher, err := NewIgnoreMatcher(tmpDir, []string{}, "")
+	if err != nil {
+		t.Fatalf("failed to create ignore matcher: %v", err)
+	}
+
+	scanner := NewScanner(tmpDir, matcher)
+	files, _, err := scanner.Scan()
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+
+	// Should find main.go but not .hidden/secret.go
+	if len(files) != 1 {
+		t.Errorf("expected 1 file, got %d", len(files))
+		for _, f := range files {
+			t.Logf("  found: %s", f.Path)
+		}
+	} else if files[0].Path != "main.go" {
+		t.Errorf("expected main.go, got %s", files[0].Path)
+	}
+}


### PR DESCRIPTION
## Description

The root directory path (".") returned by `filepath.Rel(root, root)` was being matched against `.gitignore` patterns like `.*/`, causing the entire directory tree to be skipped during indexing.

Add an early return in ShouldIgnore() to never ignore the root path `.`, ensuring that patterns intended for hidden directories don't block the root.

Add two regression tests:
- `TestShouldIgnore_RootDotPath`: Verifies root is never ignored
- `TestScanner_DotStarSlashGitignoreDoesNotBlockAll`: Verifies scanner finds files when `.gitignore` contains `.*/` pattern


## Related Issue

Fixes #202

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

**Test Configuration:**
- OS: MacOs
- Go version: 1.23.2
- Embedding provider: LM Studio

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's code style
- [x] I have run `golangci-lint run` and fixed any issues
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed
- [x] I have added an entry to CHANGELOG.md (if applicable)
- [x] My changes generate no new warnings
- [x] All new and existing tests pass
