### PR TITLE
fix(qdrant): enable incremental indexing via doc_hash on chunk points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Explicit linked-worktree watch opt-in**: `grepai watch --all-worktrees` now enables linked worktree fanout only when requested, keeping default watch sessions scoped to the current worktree.
+
+### Fixed
+
+- **MCP workspace startup refresh**: `grepai mcp-serve --workspace <name>` now keeps full-workspace indexing explicit while refreshing only the local project context when started inside a workspace project.
+- **Linked worktree auto-init detection**: linked worktree watch discovery now treats missing `.grepai/config.yaml` as uninitialized, even when a partial `.grepai/` directory already exists.
+- **Qdrant file counts**: `status` and MCP index status now report file counts correctly for Qdrant-backed indexes instead of always showing `0`.
+
+### Documentation
+
+- Update git worktree and workspace/MCP docs to describe the new watch opt-in and MCP startup behavior.
+
 ## [0.35.0] - 2026-03-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **MCP workspace startup refresh**: `grepai mcp-serve --workspace <name>` now keeps full-workspace indexing explicit while refreshing only the local project context when started inside a workspace project.
 - **Linked worktree auto-init detection**: linked worktree watch discovery now treats missing `.grepai/config.yaml` as uninitialized, even when a partial `.grepai/` directory already exists.
-- **Qdrant file counts**: `status` and MCP index status now report file counts correctly for Qdrant-backed indexes instead of always showing `0`.
+- **Qdrant file counts**: `status` and MCP index status now report file counts correctly for Qdrant-backed indexes, including collections that span multiple scroll pages, instead of always showing `0` or truncating counts to one page.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MCP workspace startup refresh**: `grepai mcp-serve --workspace <name>` now keeps full-workspace indexing explicit while refreshing only the local project context when started inside a workspace project.
 - **Linked worktree auto-init detection**: linked worktree watch discovery now treats missing `.grepai/config.yaml` as uninitialized, even when a partial `.grepai/` directory already exists.
 - **Qdrant file counts**: `status` and MCP index status now report file counts correctly for Qdrant-backed indexes, including collections that span multiple scroll pages, instead of always showing `0` or truncating counts to one page.
+- **Qdrant incremental indexing**: Qdrant backend now tracks document hashes (`doc_hash`) on chunk points, enabling `grepai watch` to skip unchanged files on restart instead of re-embedding the entire codebase. Legacy indexes are migrated transparently on first run.
 
 ### Documentation
 

--- a/cli/mcp_serve.go
+++ b/cli/mcp_serve.go
@@ -12,6 +12,14 @@ import (
 	"github.com/yoanbernabeu/grepai/mcp"
 )
 
+var (
+	mcpResolveTargetRunner          = resolveMCPTarget
+	mcpRefreshStartupRunner         = refreshMCPStartup
+	mcpNewServerRunner              = mcp.NewServer
+	mcpNewServerWithWorkspaceRunner = mcp.NewServerWithWorkspace
+	mcpServeRunner                  = func(srv *mcp.Server) error { return srv.Serve() }
+)
+
 var mcpServeCmd = &cobra.Command{
 	Use:   "mcp-serve [project-path]",
 	Short: "Start grepai as an MCP server",
@@ -155,23 +163,23 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 		explicitPath = args[0]
 	}
 
-	projectRoot, wsName, err := resolveMCPTarget(explicitPath, workspaceFlag)
+	projectRoot, wsName, err := mcpResolveTargetRunner(explicitPath, workspaceFlag)
 	if err != nil {
 		return err
 	}
-	if err := refreshMCPStartup(context.Background(), projectRoot, wsName); err != nil {
+	if err := mcpRefreshStartupRunner(context.Background(), projectRoot, wsName); err != nil {
 		log.Printf("Warning: failed to refresh local project context for MCP startup: %v", err)
 	}
 
 	var srv *mcp.Server
 	if wsName != "" {
-		srv, err = mcp.NewServerWithWorkspace(projectRoot, wsName)
+		srv, err = mcpNewServerWithWorkspaceRunner(projectRoot, wsName)
 	} else {
-		srv, err = mcp.NewServer(projectRoot)
+		srv, err = mcpNewServerRunner(projectRoot)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to create MCP server: %w", err)
 	}
 
-	return srv.Serve()
+	return mcpServeRunner(srv)
 }

--- a/cli/mcp_serve.go
+++ b/cli/mcp_serve.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -84,10 +86,11 @@ func resolveMCPTarget(explicitPath, workspaceName string) (string, string, error
 			return "", "", fmt.Errorf("workspace %q not found", workspaceName)
 		}
 
-		// Check if cwd has local config (optional, for trace tools)
 		projectRoot := ""
-		if pr, err := config.FindProjectRoot(); err == nil {
-			projectRoot = pr
+		if cwd, err := os.Getwd(); err == nil {
+			if resolvedName, _, project, projectErr := cfg.FindWorkspaceProjectForPath(cwd); projectErr == nil && project != nil && resolvedName == workspaceName {
+				projectRoot = project.Path
+			}
 		}
 
 		return projectRoot, workspaceName, nil
@@ -155,6 +158,9 @@ func runMCPServe(cmd *cobra.Command, args []string) error {
 	projectRoot, wsName, err := resolveMCPTarget(explicitPath, workspaceFlag)
 	if err != nil {
 		return err
+	}
+	if err := refreshMCPStartup(context.Background(), projectRoot, wsName); err != nil {
+		log.Printf("Warning: failed to refresh local project context for MCP startup: %v", err)
 	}
 
 	var srv *mcp.Server

--- a/cli/mcp_serve_test.go
+++ b/cli/mcp_serve_test.go
@@ -1,12 +1,16 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/yoanbernabeu/grepai/config"
+	"github.com/yoanbernabeu/grepai/mcp"
 )
 
 func TestResolveMCPWorkspace(t *testing.T) {
@@ -169,4 +173,122 @@ func TestResolveMCPWorkspace(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+}
+
+func TestRunMCPServe_RefreshesWorkspaceProjectBeforeServe(t *testing.T) {
+	oldResolve := mcpResolveTargetRunner
+	oldRefresh := mcpRefreshStartupRunner
+	oldNewServer := mcpNewServerRunner
+	oldNewServerWithWorkspace := mcpNewServerWithWorkspaceRunner
+	oldServe := mcpServeRunner
+	defer func() {
+		mcpResolveTargetRunner = oldResolve
+		mcpRefreshStartupRunner = oldRefresh
+		mcpNewServerRunner = oldNewServer
+		mcpNewServerWithWorkspaceRunner = oldNewServerWithWorkspace
+		mcpServeRunner = oldServe
+	}()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("workspace", "", "")
+	if err := cmd.Flags().Set("workspace", "test"); err != nil {
+		t.Fatalf("failed to set workspace flag: %v", err)
+	}
+
+	var resolvedExplicitPath, resolvedWorkspace string
+	mcpResolveTargetRunner = func(explicitPath, workspaceFlag string) (string, string, error) {
+		resolvedExplicitPath = explicitPath
+		resolvedWorkspace = workspaceFlag
+		return "/tmp/project", "test", nil
+	}
+
+	var refreshProjectRoot, refreshWorkspace string
+	mcpRefreshStartupRunner = func(_ context.Context, projectRoot, workspaceName string) error {
+		refreshProjectRoot = projectRoot
+		refreshWorkspace = workspaceName
+		return nil
+	}
+
+	var serverProjectRoot, serverWorkspace string
+	mcpNewServerWithWorkspaceRunner = func(projectRoot, workspaceName string) (*mcp.Server, error) {
+		serverProjectRoot = projectRoot
+		serverWorkspace = workspaceName
+		return &mcp.Server{}, nil
+	}
+	mcpNewServerRunner = func(projectRoot string) (*mcp.Server, error) {
+		t.Fatalf("unexpected non-workspace server creation for projectRoot %q", projectRoot)
+		return nil, nil
+	}
+
+	served := false
+	mcpServeRunner = func(_ *mcp.Server) error {
+		served = true
+		return nil
+	}
+
+	if err := runMCPServe(cmd, nil); err != nil {
+		t.Fatalf("runMCPServe failed: %v", err)
+	}
+	if resolvedExplicitPath != "" || resolvedWorkspace != "test" {
+		t.Fatalf("resolve args = (%q, %q), want (\"\", \"test\")", resolvedExplicitPath, resolvedWorkspace)
+	}
+	if refreshProjectRoot != "/tmp/project" || refreshWorkspace != "test" {
+		t.Fatalf("refresh args = (%q, %q), want (%q, %q)", refreshProjectRoot, refreshWorkspace, "/tmp/project", "test")
+	}
+	if serverProjectRoot != "/tmp/project" || serverWorkspace != "test" {
+		t.Fatalf("workspace server args = (%q, %q), want (%q, %q)", serverProjectRoot, serverWorkspace, "/tmp/project", "test")
+	}
+	if !served {
+		t.Fatal("expected MCP server to be served")
+	}
+}
+
+func TestRunMCPServe_ContinuesWhenRefreshFails(t *testing.T) {
+	oldResolve := mcpResolveTargetRunner
+	oldRefresh := mcpRefreshStartupRunner
+	oldNewServer := mcpNewServerRunner
+	oldNewServerWithWorkspace := mcpNewServerWithWorkspaceRunner
+	oldServe := mcpServeRunner
+	defer func() {
+		mcpResolveTargetRunner = oldResolve
+		mcpRefreshStartupRunner = oldRefresh
+		mcpNewServerRunner = oldNewServer
+		mcpNewServerWithWorkspaceRunner = oldNewServerWithWorkspace
+		mcpServeRunner = oldServe
+	}()
+
+	cmd := &cobra.Command{}
+
+	mcpResolveTargetRunner = func(explicitPath, workspaceFlag string) (string, string, error) {
+		return "/tmp/project", "", nil
+	}
+	mcpRefreshStartupRunner = func(_ context.Context, projectRoot, workspaceName string) error {
+		if projectRoot != "/tmp/project" || workspaceName != "" {
+			t.Fatalf("refresh args = (%q, %q), want (%q, %q)", projectRoot, workspaceName, "/tmp/project", "")
+		}
+		return errors.New("refresh failed")
+	}
+	mcpNewServerRunner = func(projectRoot string) (*mcp.Server, error) {
+		if projectRoot != "/tmp/project" {
+			t.Fatalf("project server root = %q, want %q", projectRoot, "/tmp/project")
+		}
+		return &mcp.Server{}, nil
+	}
+	mcpNewServerWithWorkspaceRunner = func(projectRoot, workspaceName string) (*mcp.Server, error) {
+		t.Fatalf("unexpected workspace server creation for (%q, %q)", projectRoot, workspaceName)
+		return nil, nil
+	}
+
+	served := false
+	mcpServeRunner = func(_ *mcp.Server) error {
+		served = true
+		return nil
+	}
+
+	if err := runMCPServe(cmd, nil); err != nil {
+		t.Fatalf("runMCPServe failed: %v", err)
+	}
+	if !served {
+		t.Fatal("expected MCP server to be served even when refresh fails")
+	}
 }

--- a/cli/mcp_serve_test.go
+++ b/cli/mcp_serve_test.go
@@ -30,6 +30,18 @@ func TestResolveMCPWorkspace(t *testing.T) {
 		})
 		config.SaveWorkspaceConfig(cfg)
 
+		if err := os.MkdirAll(filepath.Join(tmpDir, "pipeline", "src"), 0o755); err != nil {
+			t.Fatalf("failed to create pipeline dir: %v", err)
+		}
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("failed to get cwd: %v", err)
+		}
+		defer func() { _ = os.Chdir(wd) }()
+		if err := os.Chdir(filepath.Join(tmpDir, "pipeline", "src")); err != nil {
+			t.Fatalf("failed to chdir into workspace project: %v", err)
+		}
+
 		projectRoot, wsName, err := resolveMCPTarget("", "test")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -37,7 +49,9 @@ func TestResolveMCPWorkspace(t *testing.T) {
 		if wsName != "test" {
 			t.Errorf("expected workspace test, got %s", wsName)
 		}
-		_ = projectRoot
+		if projectRoot != filepath.Join(tmpDir, "pipeline") {
+			t.Fatalf("expected projectRoot %q, got %q", filepath.Join(tmpDir, "pipeline"), projectRoot)
+		}
 	})
 
 	t.Run("explicit_workspace_not_found", func(t *testing.T) {

--- a/cli/mcp_startup_refresh.go
+++ b/cli/mcp_startup_refresh.go
@@ -6,33 +6,41 @@ import (
 	"github.com/yoanbernabeu/grepai/config"
 )
 
+var (
+	mcpFindWorkspaceProjectForPathRunner = config.FindWorkspaceProjectForPath
+	mcpValidateWorkspaceBackendRunner    = config.ValidateWorkspaceBackend
+	mcpInitializeEmbedderRunner          = initializeEmbedder
+	mcpInitializeWorkspaceStoreRunner    = initializeWorkspaceStore
+	mcpStartupRefreshRunner              = runWorkspaceProjectStartupRefresh
+)
+
 func refreshMCPStartup(ctx context.Context, projectRoot, workspaceName string) error {
 	if workspaceName == "" || projectRoot == "" {
 		return nil
 	}
 
-	resolvedWorkspaceName, ws, project, err := config.FindWorkspaceProjectForPath(projectRoot)
+	resolvedWorkspaceName, ws, project, err := mcpFindWorkspaceProjectForPathRunner(projectRoot)
 	if err != nil {
 		return err
 	}
 	if ws == nil || project == nil || resolvedWorkspaceName != workspaceName {
 		return nil
 	}
-	if err := config.ValidateWorkspaceBackend(ws); err != nil {
+	if err := mcpValidateWorkspaceBackendRunner(ws); err != nil {
 		return err
 	}
 
-	emb, err := initializeEmbedder(ctx, &config.Config{Embedder: ws.Embedder})
+	emb, err := mcpInitializeEmbedderRunner(ctx, &config.Config{Embedder: ws.Embedder})
 	if err != nil {
 		return err
 	}
 	defer emb.Close()
 
-	sharedStore, err := initializeWorkspaceStore(ctx, ws)
+	sharedStore, err := mcpInitializeWorkspaceStoreRunner(ctx, ws)
 	if err != nil {
 		return err
 	}
 	defer sharedStore.Close()
 
-	return runWorkspaceProjectStartupRefresh(ctx, ws, *project, emb, sharedStore, true)
+	return mcpStartupRefreshRunner(ctx, ws, *project, emb, sharedStore, true)
 }

--- a/cli/mcp_startup_refresh.go
+++ b/cli/mcp_startup_refresh.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/yoanbernabeu/grepai/config"
+)
+
+func refreshMCPStartup(ctx context.Context, projectRoot, workspaceName string) error {
+	if workspaceName == "" || projectRoot == "" {
+		return nil
+	}
+
+	resolvedWorkspaceName, ws, project, err := config.FindWorkspaceProjectForPath(projectRoot)
+	if err != nil {
+		return err
+	}
+	if ws == nil || project == nil || resolvedWorkspaceName != workspaceName {
+		return nil
+	}
+	if err := config.ValidateWorkspaceBackend(ws); err != nil {
+		return err
+	}
+
+	emb, err := initializeEmbedder(ctx, &config.Config{Embedder: ws.Embedder})
+	if err != nil {
+		return err
+	}
+	defer emb.Close()
+
+	sharedStore, err := initializeWorkspaceStore(ctx, ws)
+	if err != nil {
+		return err
+	}
+	defer sharedStore.Close()
+
+	return runWorkspaceProjectStartupRefresh(ctx, ws, *project, emb, sharedStore, true)
+}

--- a/cli/mcp_startup_refresh_test.go
+++ b/cli/mcp_startup_refresh_test.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yoanbernabeu/grepai/config"
+	"github.com/yoanbernabeu/grepai/embedder"
+	"github.com/yoanbernabeu/grepai/store"
+)
+
+func TestRefreshMCPStartup_NoopWithoutRequiredContext(t *testing.T) {
+	oldFind := mcpFindWorkspaceProjectForPathRunner
+	oldValidate := mcpValidateWorkspaceBackendRunner
+	oldInitEmbedder := mcpInitializeEmbedderRunner
+	oldInitStore := mcpInitializeWorkspaceStoreRunner
+	oldRefresh := mcpStartupRefreshRunner
+	defer func() {
+		mcpFindWorkspaceProjectForPathRunner = oldFind
+		mcpValidateWorkspaceBackendRunner = oldValidate
+		mcpInitializeEmbedderRunner = oldInitEmbedder
+		mcpInitializeWorkspaceStoreRunner = oldInitStore
+		mcpStartupRefreshRunner = oldRefresh
+	}()
+
+	mcpFindWorkspaceProjectForPathRunner = func(path string) (string, *config.Workspace, *config.ProjectEntry, error) {
+		t.Fatalf("unexpected workspace lookup for %q", path)
+		return "", nil, nil, nil
+	}
+	mcpValidateWorkspaceBackendRunner = func(ws *config.Workspace) error {
+		t.Fatalf("unexpected workspace validation for %v", ws)
+		return nil
+	}
+	mcpInitializeEmbedderRunner = func(ctx context.Context, cfg *config.Config) (embedder.Embedder, error) {
+		t.Fatalf("unexpected embedder init for %+v", cfg)
+		return nil, nil
+	}
+	mcpInitializeWorkspaceStoreRunner = func(ctx context.Context, ws *config.Workspace) (store.VectorStore, error) {
+		t.Fatalf("unexpected workspace store init for %v", ws)
+		return nil, nil
+	}
+	mcpStartupRefreshRunner = func(ctx context.Context, ws *config.Workspace, project config.ProjectEntry, emb embedder.Embedder, sharedStore store.VectorStore, isBackgroundChild bool) error {
+		t.Fatalf("unexpected refresh for workspace=%v project=%v", ws, project)
+		return nil
+	}
+
+	if err := refreshMCPStartup(context.Background(), "", "test"); err != nil {
+		t.Fatalf("workspace-only no-op failed: %v", err)
+	}
+	if err := refreshMCPStartup(context.Background(), "/tmp/project", ""); err != nil {
+		t.Fatalf("project-only no-op failed: %v", err)
+	}
+}
+
+func TestRefreshMCPStartup_NoopWhenWorkspaceMismatch(t *testing.T) {
+	oldFind := mcpFindWorkspaceProjectForPathRunner
+	oldValidate := mcpValidateWorkspaceBackendRunner
+	oldInitEmbedder := mcpInitializeEmbedderRunner
+	oldInitStore := mcpInitializeWorkspaceStoreRunner
+	oldRefresh := mcpStartupRefreshRunner
+	defer func() {
+		mcpFindWorkspaceProjectForPathRunner = oldFind
+		mcpValidateWorkspaceBackendRunner = oldValidate
+		mcpInitializeEmbedderRunner = oldInitEmbedder
+		mcpInitializeWorkspaceStoreRunner = oldInitStore
+		mcpStartupRefreshRunner = oldRefresh
+	}()
+
+	project := &config.ProjectEntry{Name: "proj", Path: "/tmp/project"}
+	ws := &config.Workspace{Name: "other"}
+	mcpFindWorkspaceProjectForPathRunner = func(path string) (string, *config.Workspace, *config.ProjectEntry, error) {
+		if path != "/tmp/project" {
+			t.Fatalf("workspace lookup path = %q, want %q", path, "/tmp/project")
+		}
+		return "other", ws, project, nil
+	}
+	mcpValidateWorkspaceBackendRunner = func(ws *config.Workspace) error {
+		t.Fatalf("unexpected validation for workspace %q", ws.Name)
+		return nil
+	}
+	mcpInitializeEmbedderRunner = func(ctx context.Context, cfg *config.Config) (embedder.Embedder, error) {
+		t.Fatal("unexpected embedder init")
+		return nil, nil
+	}
+	mcpInitializeWorkspaceStoreRunner = func(ctx context.Context, ws *config.Workspace) (store.VectorStore, error) {
+		t.Fatal("unexpected workspace store init")
+		return nil, nil
+	}
+	mcpStartupRefreshRunner = func(ctx context.Context, ws *config.Workspace, project config.ProjectEntry, emb embedder.Embedder, sharedStore store.VectorStore, isBackgroundChild bool) error {
+		t.Fatal("unexpected startup refresh")
+		return nil
+	}
+
+	if err := refreshMCPStartup(context.Background(), "/tmp/project", "test"); err != nil {
+		t.Fatalf("mismatch no-op failed: %v", err)
+	}
+}
+
+func TestRefreshMCPStartup_RefreshesMatchingWorkspaceProject(t *testing.T) {
+	oldFind := mcpFindWorkspaceProjectForPathRunner
+	oldValidate := mcpValidateWorkspaceBackendRunner
+	oldInitEmbedder := mcpInitializeEmbedderRunner
+	oldInitStore := mcpInitializeWorkspaceStoreRunner
+	oldRefresh := mcpStartupRefreshRunner
+	defer func() {
+		mcpFindWorkspaceProjectForPathRunner = oldFind
+		mcpValidateWorkspaceBackendRunner = oldValidate
+		mcpInitializeEmbedderRunner = oldInitEmbedder
+		mcpInitializeWorkspaceStoreRunner = oldInitStore
+		mcpStartupRefreshRunner = oldRefresh
+	}()
+
+	project := &config.ProjectEntry{Name: "proj", Path: "/tmp/project"}
+	ws := &config.Workspace{Name: "test"}
+	emb := &countingEmbedder{}
+	sharedStore := &mockVectorStore{}
+
+	mcpFindWorkspaceProjectForPathRunner = func(path string) (string, *config.Workspace, *config.ProjectEntry, error) {
+		return "test", ws, project, nil
+	}
+
+	validated := false
+	mcpValidateWorkspaceBackendRunner = func(workspace *config.Workspace) error {
+		validated = true
+		if workspace != ws {
+			t.Fatalf("validated workspace = %p, want %p", workspace, ws)
+		}
+		return nil
+	}
+
+	mcpInitializeEmbedderRunner = func(ctx context.Context, cfg *config.Config) (embedder.Embedder, error) {
+		if cfg.Embedder != ws.Embedder {
+			t.Fatalf("embedder config = %+v, want %+v", cfg.Embedder, ws.Embedder)
+		}
+		return emb, nil
+	}
+	mcpInitializeWorkspaceStoreRunner = func(ctx context.Context, workspace *config.Workspace) (store.VectorStore, error) {
+		if workspace != ws {
+			t.Fatalf("workspace store init = %p, want %p", workspace, ws)
+		}
+		return sharedStore, nil
+	}
+
+	refreshCalled := false
+	mcpStartupRefreshRunner = func(ctx context.Context, workspace *config.Workspace, gotProject config.ProjectEntry, gotEmb embedder.Embedder, gotStore store.VectorStore, isBackgroundChild bool) error {
+		refreshCalled = true
+		if workspace != ws {
+			t.Fatalf("refresh workspace = %p, want %p", workspace, ws)
+		}
+		if gotProject != *project {
+			t.Fatalf("refresh project = %+v, want %+v", gotProject, *project)
+		}
+		if gotEmb != emb {
+			t.Fatalf("refresh embedder = %T, want %T", gotEmb, emb)
+		}
+		if gotStore != sharedStore {
+			t.Fatalf("refresh store = %T, want %T", gotStore, sharedStore)
+		}
+		if !isBackgroundChild {
+			t.Fatal("expected startup refresh to run with background-child semantics")
+		}
+		return nil
+	}
+
+	if err := refreshMCPStartup(context.Background(), "/tmp/project", "test"); err != nil {
+		t.Fatalf("refreshMCPStartup failed: %v", err)
+	}
+	if !validated {
+		t.Fatal("expected workspace backend validation")
+	}
+	if !refreshCalled {
+		t.Fatal("expected startup refresh to run")
+	}
+}
+
+func TestRefreshMCPStartup_PropagatesLookupError(t *testing.T) {
+	oldFind := mcpFindWorkspaceProjectForPathRunner
+	defer func() { mcpFindWorkspaceProjectForPathRunner = oldFind }()
+
+	wantErr := errors.New("lookup failed")
+	mcpFindWorkspaceProjectForPathRunner = func(path string) (string, *config.Workspace, *config.ProjectEntry, error) {
+		return "", nil, nil, wantErr
+	}
+
+	if err := refreshMCPStartup(context.Background(), "/tmp/project", "test"); !errors.Is(err, wantErr) {
+		t.Fatalf("expected lookup failure %v, got %v", wantErr, err)
+	}
+}

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -44,6 +44,10 @@ var (
 	watchForegroundRunner      = runWatchForeground
 	watchForegroundUIRunner    = runWatchForegroundUI
 	watchStopDaemonRunner      = stopWatchDaemon
+	watchSpawnBackgroundRunner = daemon.SpawnBackground
+	watchSpawnWorktreeRunner   = daemon.SpawnWorktreeBackground
+	watchReadyChecker          = daemon.IsReady
+	watchWorktreeReadyChecker  = daemon.IsWorktreeReady
 )
 
 var watchCmd = &cobra.Command{
@@ -369,9 +373,9 @@ func startBackgroundWatch(logDir, worktreeID string) error {
 	var childPID int
 	var exitCh <-chan struct{}
 	if worktreeID != "" {
-		childPID, exitCh, err = daemon.SpawnWorktreeBackground(logDir, worktreeID, args)
+		childPID, exitCh, err = watchSpawnWorktreeRunner(logDir, worktreeID, args)
 	} else {
-		childPID, exitCh, err = daemon.SpawnBackground(logDir, args)
+		childPID, exitCh, err = watchSpawnBackgroundRunner(logDir, args)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to start background process: %w", err)
@@ -387,9 +391,9 @@ func startBackgroundWatch(logDir, worktreeID string) error {
 		// Check if ready file exists (initialization succeeded)
 		var isReady bool
 		if worktreeID != "" {
-			isReady = daemon.IsWorktreeReady(logDir, worktreeID)
+			isReady = watchWorktreeReadyChecker(logDir, worktreeID)
 		} else {
-			isReady = daemon.IsReady(logDir)
+			isReady = watchReadyChecker(logDir)
 		}
 
 		if isReady {

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -29,12 +29,13 @@ import (
 )
 
 var (
-	watchBackground bool
-	watchLogDir     string
-	watchStatus     bool
-	watchStop       bool
-	watchWorkspace  string
-	watchNoUI       bool
+	watchBackground   bool
+	watchLogDir       string
+	watchStatus       bool
+	watchStop         bool
+	watchWorkspace    string
+	watchAllWorktrees bool
+	watchNoUI         bool
 )
 
 var (
@@ -64,6 +65,9 @@ Background mode:
   grepai watch --status                  Check if background watcher is running
   grepai watch --stop                    Stop the background watcher
 
+Linked worktrees:
+  grepai watch --all-worktrees           Also watch linked git worktrees from the main worktree
+
 Default log directories:
   Linux:   ~/.local/state/grepai/logs/grepai-watch.log (or $XDG_STATE_HOME)
   macOS:   ~/Library/Logs/grepai/grepai-watch.log
@@ -83,6 +87,7 @@ func init() {
 	watchCmd.Flags().BoolVar(&watchStatus, "status", false, "Show background watcher status")
 	watchCmd.Flags().BoolVar(&watchStop, "stop", false, "Stop the background watcher")
 	watchCmd.Flags().StringVar(&watchWorkspace, "workspace", "", "Workspace name for multi-project mode")
+	watchCmd.Flags().BoolVar(&watchAllWorktrees, "all-worktrees", false, "Also watch linked git worktrees from the main worktree")
 	watchCmd.Flags().BoolVar(&watchNoUI, "no-ui", false, "Disable interactive UI in foreground mode")
 }
 
@@ -100,6 +105,9 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	}
 	if activeFlags > 1 {
 		return fmt.Errorf("flags --background, --status, and --stop are mutually exclusive")
+	}
+	if watchWorkspace != "" && watchAllWorktrees {
+		return fmt.Errorf("--all-worktrees cannot be used with --workspace")
 	}
 
 	// Determine log directory
@@ -352,6 +360,9 @@ func startBackgroundWatch(logDir, worktreeID string) error {
 	args := []string{"watch"}
 	if watchLogDir != "" {
 		args = append(args, "--log-dir", watchLogDir)
+	}
+	if watchAllWorktrees {
+		args = append(args, "--all-worktrees")
 	}
 
 	// Spawn background process
@@ -892,8 +903,7 @@ func discoverWorktreesForWatch(projectRoot string) []string {
 			seen[wtPathCanonical] = true
 			// Auto-init .grepai/ if needed (FindProjectRoot does this when called
 			// from within the worktree, but we're not in it, so init manually)
-			localGrepai := filepath.Join(wtPathCanonical, ".grepai")
-			if _, statErr := os.Stat(localGrepai); os.IsNotExist(statErr) {
+			if !config.Exists(wtPathCanonical) {
 				// Auto-init from main
 				if initErr := config.AutoInitWorktree(wtPathCanonical, projectRootCanonical); initErr != nil {
 					log.Printf("Warning: failed to auto-init worktree %s: %v", wtPathCanonical, initErr)
@@ -905,6 +915,13 @@ func discoverWorktreesForWatch(projectRoot string) []string {
 		}
 	}
 	return worktrees
+}
+
+func linkedWorktreesForCurrentWatch(projectRoot string) []string {
+	if !watchAllWorktrees {
+		return nil
+	}
+	return discoverWorktreesForWatch(projectRoot)
 }
 
 func canonicalPath(path string) string {
@@ -1849,17 +1866,17 @@ func runWatchForeground() error {
 	}
 	defer emb.Close()
 
-	// Discover linked worktrees (only from main worktree) for initial ready semantics.
-	linkedWorktrees := discoverWorktreesForWatch(projectRoot)
+	// Discover linked worktrees only when explicitly requested.
+	linkedWorktrees := linkedWorktreesForCurrentWatch(projectRoot)
 	initialTotalProjects := 1 + len(linkedWorktrees)
 	if len(linkedWorktrees) > 0 {
 		if !isBackgroundChild {
-			fmt.Printf("Detected %d linked worktree(s), watching all:\n", len(linkedWorktrees))
+			fmt.Printf("Detected %d linked worktree(s), watching with --all-worktrees:\n", len(linkedWorktrees))
 			for _, wt := range linkedWorktrees {
 				fmt.Printf("  - %s\n", wt)
 			}
 		} else {
-			log.Printf("Detected %d linked worktree(s), watching all", len(linkedWorktrees))
+			log.Printf("Detected %d linked worktree(s), watching with --all-worktrees", len(linkedWorktrees))
 			for _, wt := range linkedWorktrees {
 				log.Printf("  - %s", wt)
 			}
@@ -2578,6 +2595,7 @@ type workspaceProjectRuntime struct {
 	project         config.ProjectEntry
 	cfg             *config.Config
 	idx             *indexer.Indexer
+	ignoreMatcher   *indexer.IgnoreMatcher
 	scanner         *indexer.Scanner
 	extractor       *trace.RegexExtractor
 	symbolStore     *trace.GOBSymbolStore
@@ -2591,75 +2609,37 @@ type workspaceProjectRuntime struct {
 }
 
 func initializeWorkspaceRuntime(ctx context.Context, ws *config.Workspace, project config.ProjectEntry, emb embedder.Embedder, sharedStore store.VectorStore, isBackgroundChild bool) (*workspaceProjectRuntime, *watcher.Watcher, error) {
-	projectCfg := config.DefaultConfig()
-	if config.Exists(project.Path) {
-		loadedCfg, err := config.Load(project.Path)
-		if err != nil {
-			log.Printf("Warning: failed to load config for %s, using defaults: %v", project.Name, err)
-		} else {
-			projectCfg = loadedCfg
-		}
-	}
-
-	ignoreMatcher, err := indexer.NewIgnoreMatcher(project.Path, projectCfg.Ignore, projectCfg.ExternalGitignore)
+	runtime, err := newWorkspaceProjectRuntime(ctx, ws, project, emb, sharedStore)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize ignore matcher: %w", err)
-	}
-
-	scanner := indexer.NewScanner(project.Path, ignoreMatcher)
-	chunker := indexer.NewChunker(projectCfg.Chunking.Size, projectCfg.Chunking.Overlap)
-	vectorStore := &projectPrefixStore{
-		store:         sharedStore,
-		workspaceName: ws.Name,
-		projectName:   project.Name,
-		projectPath:   project.Path,
-	}
-	idx := indexer.NewIndexer(project.Path, vectorStore, emb, chunker, scanner, projectCfg.Watch.LastIndexTime)
-	extractor := trace.NewRegexExtractor()
-	symbolStore := trace.NewGOBSymbolStore(config.GetSymbolIndexPath(project.Path))
-	if err := symbolStore.Load(ctx); err != nil {
-		log.Printf("Warning: failed to load symbol index for %s: %v", project.Path, err)
-	}
-
-	tracedLanguages := projectCfg.Trace.EnabledLanguages
-	if len(tracedLanguages) == 0 {
-		tracedLanguages = []string{".go", ".js", ".ts", ".jsx", ".tsx", ".py", ".php", ".lua", ".java", ".cs", ".fs", ".fsx", ".fsi"}
-	}
-
-	stats, err := runInitialScan(ctx, idx, scanner, extractor, symbolStore, tracedLanguages, projectCfg.Watch.LastIndexTime, isBackgroundChild, nil, nil)
-	if err != nil {
-		_ = symbolStore.Close()
 		return nil, nil, err
 	}
-	if stats.FilesIndexed > 0 || stats.ChunksCreated > 0 {
-		projectCfg.Watch.LastIndexTime = time.Now()
-		if err := projectCfg.Save(project.Path); err != nil {
-			log.Printf("Warning: failed to save config for %s: %v", project.Name, err)
-		}
+	if err := runWorkspaceProjectInitialScan(ctx, runtime, isBackgroundChild); err != nil {
+		_ = runtime.symbolStore.Close()
+		return nil, nil, err
 	}
 
 	var rpgStore rpg.RPGStore
 	var rpgEncoder *rpg.RPGEncoder
 	var manager *rpgRealtimeManager
-	if projectCfg.RPG.Enabled {
+	if runtime.cfg.RPG.Enabled {
 		rpgStore = rpg.NewGOBRPGStore(config.GetRPGIndexPath(project.Path))
 		if err := rpgStore.Load(ctx); err != nil {
 			log.Printf("Warning: failed to load RPG index for %s: %v", project.Path, err)
 		}
 
 		var featureExtractor rpg.FeatureExtractor
-		switch projectCfg.RPG.FeatureMode {
+		switch runtime.cfg.RPG.FeatureMode {
 		case "llm", "hybrid":
-			if projectCfg.RPG.LLMEndpoint == "" || projectCfg.RPG.LLMModel == "" {
-				log.Printf("Warning: RPG feature_mode=%q but llm_endpoint or llm_model is empty for %s, falling back to local extractor", projectCfg.RPG.FeatureMode, project.Path)
+			if runtime.cfg.RPG.LLMEndpoint == "" || runtime.cfg.RPG.LLMModel == "" {
+				log.Printf("Warning: RPG feature_mode=%q but llm_endpoint or llm_model is empty for %s, falling back to local extractor", runtime.cfg.RPG.FeatureMode, project.Path)
 				featureExtractor = rpg.NewLocalExtractor()
 			} else {
 				featureExtractor = rpg.NewLLMExtractor(rpg.LLMExtractorConfig{
-					Provider: projectCfg.RPG.LLMProvider,
-					Model:    projectCfg.RPG.LLMModel,
-					Endpoint: projectCfg.RPG.LLMEndpoint,
-					APIKey:   projectCfg.RPG.LLMAPIKey,
-					Timeout:  time.Duration(projectCfg.RPG.LLMTimeoutMs) * time.Millisecond,
+					Provider: runtime.cfg.RPG.LLMProvider,
+					Model:    runtime.cfg.RPG.LLMModel,
+					Endpoint: runtime.cfg.RPG.LLMEndpoint,
+					APIKey:   runtime.cfg.RPG.LLMAPIKey,
+					Timeout:  time.Duration(runtime.cfg.RPG.LLMTimeoutMs) * time.Millisecond,
 				})
 			}
 		default:
@@ -2667,27 +2647,27 @@ func initializeWorkspaceRuntime(ctx context.Context, ws *config.Workspace, proje
 		}
 
 		rpgEncoder = rpg.NewRPGEncoder(rpgStore, featureExtractor, project.Path, rpg.RPGEncoderConfig{
-			DriftThreshold:       projectCfg.RPG.DriftThreshold,
-			MaxTraversalDepth:    projectCfg.RPG.MaxTraversalDepth,
-			FeatureGroupStrategy: projectCfg.RPG.FeatureGroupStrategy,
+			DriftThreshold:       runtime.cfg.RPG.DriftThreshold,
+			MaxTraversalDepth:    runtime.cfg.RPG.MaxTraversalDepth,
+			FeatureGroupStrategy: runtime.cfg.RPG.FeatureGroupStrategy,
 		})
-		if err := rpgEncoder.BuildFull(ctx, symbolStore, vectorStore, nil); err != nil {
+		if err := rpgEncoder.BuildFull(ctx, runtime.symbolStore, runtime.vectorStore, nil); err != nil {
 			log.Printf("Warning: failed to build RPG graph for %s: %v", project.Path, err)
 		}
 		if err := rpgStore.Persist(ctx); err != nil {
 			log.Printf("Warning: failed to persist RPG graph for %s: %v", project.Path, err)
 		}
 
-		manager = newRPGRealtimeManager(projectCfg.Watch.RPGMaxDirtyFilesPerBatch)
-		startRPGRealtimeWorkers(ctx, fmt.Sprintf("workspace:%s/%s", ws.Name, project.Name), symbolStore, rpgEncoder, rpgStore, projectCfg.Watch, manager)
+		manager = newRPGRealtimeManager(runtime.cfg.Watch.RPGMaxDirtyFilesPerBatch)
+		startRPGRealtimeWorkers(ctx, fmt.Sprintf("workspace:%s/%s", ws.Name, project.Name), runtime.symbolStore, rpgEncoder, rpgStore, runtime.cfg.Watch, manager)
 	}
 
-	w, err := watcher.NewWatcher(project.Path, ignoreMatcher, projectCfg.Watch.DebounceMs)
+	w, err := watcher.NewWatcher(project.Path, runtime.ignoreMatcher, runtime.cfg.Watch.DebounceMs)
 	if err != nil {
 		if rpgStore != nil {
 			_ = rpgStore.Close()
 		}
-		_ = symbolStore.Close()
+		_ = runtime.symbolStore.Close()
 		return nil, nil, fmt.Errorf("failed to create watcher: %w", err)
 	}
 	if err := w.Start(ctx); err != nil {
@@ -2695,24 +2675,14 @@ func initializeWorkspaceRuntime(ctx context.Context, ws *config.Workspace, proje
 		if rpgStore != nil {
 			_ = rpgStore.Close()
 		}
-		_ = symbolStore.Close()
+		_ = runtime.symbolStore.Close()
 		return nil, nil, fmt.Errorf("failed to start watcher: %w", err)
 	}
 
-	runtime := &workspaceProjectRuntime{
-		project:         project,
-		cfg:             projectCfg,
-		idx:             idx,
-		scanner:         scanner,
-		extractor:       extractor,
-		symbolStore:     symbolStore,
-		rpgEncoder:      rpgEncoder,
-		rpgStore:        rpgStore,
-		vectorStore:     vectorStore,
-		tracedLanguages: tracedLanguages,
-		manager:         manager,
-		watcher:         w,
-	}
+	runtime.rpgEncoder = rpgEncoder
+	runtime.rpgStore = rpgStore
+	runtime.manager = manager
+	runtime.watcher = w
 	return runtime, w, nil
 }
 

--- a/cli/watch_test.go
+++ b/cli/watch_test.go
@@ -447,6 +447,41 @@ func TestRunWatch_MultiWorktreeUsesUIForeground(t *testing.T) {
 	}
 }
 
+func TestRunWatch_AllWorktreesCannotBeCombinedWithWorkspace(t *testing.T) {
+	oldBackground := watchBackground
+	oldStatus := watchStatus
+	oldStop := watchStop
+	oldWorkspace := watchWorkspace
+	oldAllWorktrees := watchAllWorktrees
+	oldLogDir := watchLogDir
+	oldNoUI := watchNoUI
+	defer func() {
+		watchBackground = oldBackground
+		watchStatus = oldStatus
+		watchStop = oldStop
+		watchWorkspace = oldWorkspace
+		watchAllWorktrees = oldAllWorktrees
+		watchLogDir = oldLogDir
+		watchNoUI = oldNoUI
+	}()
+
+	watchBackground = false
+	watchStatus = false
+	watchStop = false
+	watchWorkspace = "test-ws"
+	watchAllWorktrees = true
+	watchLogDir = ""
+	watchNoUI = false
+
+	err := runWatch(nil, nil)
+	if err == nil {
+		t.Fatal("expected validation error when combining --workspace and --all-worktrees")
+	}
+	if !strings.Contains(err.Error(), "--all-worktrees cannot be used with --workspace") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLogDirectoryDefaults(t *testing.T) {
 	// Test that default log directory can be determined
 	logDir, err := daemon.GetDefaultLogDir()

--- a/cli/watch_test.go
+++ b/cli/watch_test.go
@@ -205,6 +205,80 @@ func TestStartBackgroundWatch_WorktreeAlreadyRunning(t *testing.T) {
 	}
 }
 
+func TestStartBackgroundWatch_PropagatesAllWorktreesFlag(t *testing.T) {
+	logDir := t.TempDir()
+
+	oldLogDir := watchLogDir
+	oldAllWorktrees := watchAllWorktrees
+	oldSpawnBackground := watchSpawnBackgroundRunner
+	oldReady := watchReadyChecker
+	defer func() {
+		watchLogDir = oldLogDir
+		watchAllWorktrees = oldAllWorktrees
+		watchSpawnBackgroundRunner = oldSpawnBackground
+		watchReadyChecker = oldReady
+	}()
+
+	watchLogDir = ""
+	watchAllWorktrees = true
+
+	var capturedArgs []string
+	watchSpawnBackgroundRunner = func(logDir string, args []string) (int, <-chan struct{}, error) {
+		capturedArgs = append([]string(nil), args...)
+		return 1234, make(chan struct{}), nil
+	}
+	watchReadyChecker = func(logDir string) bool {
+		return true
+	}
+
+	if err := startBackgroundWatch(logDir, ""); err != nil {
+		t.Fatalf("startBackgroundWatch() failed: %v", err)
+	}
+	if got := strings.Join(capturedArgs, " "); got != "watch --all-worktrees" {
+		t.Fatalf("spawn args = %q, want %q", got, "watch --all-worktrees")
+	}
+}
+
+func TestStartBackgroundWatch_PropagatesAllWorktreesFlagForWorktree(t *testing.T) {
+	logDir := t.TempDir()
+	worktreeID := "wt-5"
+
+	oldLogDir := watchLogDir
+	oldAllWorktrees := watchAllWorktrees
+	oldSpawnWorktree := watchSpawnWorktreeRunner
+	oldReady := watchWorktreeReadyChecker
+	defer func() {
+		watchLogDir = oldLogDir
+		watchAllWorktrees = oldAllWorktrees
+		watchSpawnWorktreeRunner = oldSpawnWorktree
+		watchWorktreeReadyChecker = oldReady
+	}()
+
+	watchLogDir = ""
+	watchAllWorktrees = true
+
+	var capturedWorktreeID string
+	var capturedArgs []string
+	watchSpawnWorktreeRunner = func(logDir, gotWorktreeID string, args []string) (int, <-chan struct{}, error) {
+		capturedWorktreeID = gotWorktreeID
+		capturedArgs = append([]string(nil), args...)
+		return 5678, make(chan struct{}), nil
+	}
+	watchWorktreeReadyChecker = func(logDir, gotWorktreeID string) bool {
+		return gotWorktreeID == worktreeID
+	}
+
+	if err := startBackgroundWatch(logDir, worktreeID); err != nil {
+		t.Fatalf("startBackgroundWatch() failed: %v", err)
+	}
+	if capturedWorktreeID != worktreeID {
+		t.Fatalf("spawn worktree ID = %q, want %q", capturedWorktreeID, worktreeID)
+	}
+	if got := strings.Join(capturedArgs, " "); got != "watch --all-worktrees" {
+		t.Fatalf("spawn args = %q, want %q", got, "watch --all-worktrees")
+	}
+}
+
 func TestRunWatch_CheckAlreadyRunning(t *testing.T) {
 	skipIfWindows(t)
 	logDir := t.TempDir()

--- a/cli/watch_worktree_discovery_test.go
+++ b/cli/watch_worktree_discovery_test.go
@@ -85,3 +85,46 @@ func TestDiscoverWorktreesForWatch_LinkedWorktreeDoesNotDiscoverSiblings(t *test
 		t.Fatalf("discoverWorktreesForWatch() returned %d worktrees for linked worktree, want 0", len(got))
 	}
 }
+
+func TestDiscoverWorktreesForWatch_ReinitializesWhenConfigMissing(t *testing.T) {
+	mainRepo, worktreePath := setupMainRepoForWorktreeDiscovery(t)
+
+	localGrepai := filepath.Join(worktreePath, ".grepai")
+	if err := os.RemoveAll(localGrepai); err != nil {
+		t.Fatalf("failed to clean worktree .grepai: %v", err)
+	}
+	if err := os.MkdirAll(localGrepai, 0755); err != nil {
+		t.Fatalf("failed to create partial .grepai: %v", err)
+	}
+
+	got := discoverWorktreesForWatch(mainRepo)
+	if len(got) != 1 {
+		t.Fatalf("discoverWorktreesForWatch() returned %d worktrees, want 1", len(got))
+	}
+
+	localConfig := filepath.Join(worktreePath, ".grepai", "config.yaml")
+	if _, err := os.Stat(localConfig); err != nil {
+		t.Fatalf("expected config.yaml to be restored, got: %v", err)
+	}
+}
+
+func TestLinkedWorktreesForCurrentWatch_RequiresOptIn(t *testing.T) {
+	mainRepo, worktreePath := setupMainRepoForWorktreeDiscovery(t)
+
+	oldAllWorktrees := watchAllWorktrees
+	defer func() { watchAllWorktrees = oldAllWorktrees }()
+
+	watchAllWorktrees = false
+	if got := linkedWorktreesForCurrentWatch(mainRepo); len(got) != 0 {
+		t.Fatalf("linkedWorktreesForCurrentWatch() returned %d worktrees without opt-in, want 0", len(got))
+	}
+
+	watchAllWorktrees = true
+	got := linkedWorktreesForCurrentWatch(mainRepo)
+	if len(got) != 1 {
+		t.Fatalf("linkedWorktreesForCurrentWatch() returned %d worktrees with opt-in, want 1", len(got))
+	}
+	if canonicalPath(got[0]) != canonicalPath(worktreePath) {
+		t.Fatalf("linkedWorktreesForCurrentWatch()[0]=%q, want %q", got[0], worktreePath)
+	}
+}

--- a/cli/workspace_runtime.go
+++ b/cli/workspace_runtime.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/yoanbernabeu/grepai/config"
+	"github.com/yoanbernabeu/grepai/embedder"
+	"github.com/yoanbernabeu/grepai/indexer"
+	"github.com/yoanbernabeu/grepai/store"
+	"github.com/yoanbernabeu/grepai/trace"
+)
+
+func newWorkspaceProjectRuntime(ctx context.Context, ws *config.Workspace, project config.ProjectEntry, emb embedder.Embedder, sharedStore store.VectorStore) (*workspaceProjectRuntime, error) {
+	projectCfg := config.DefaultConfig()
+	if config.Exists(project.Path) {
+		loadedCfg, err := config.Load(project.Path)
+		if err != nil {
+			log.Printf("Warning: failed to load config for %s, using defaults: %v", project.Name, err)
+		} else {
+			projectCfg = loadedCfg
+		}
+	}
+
+	ignoreMatcher, err := indexer.NewIgnoreMatcher(project.Path, projectCfg.Ignore, projectCfg.ExternalGitignore)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize ignore matcher: %w", err)
+	}
+
+	scanner := indexer.NewScanner(project.Path, ignoreMatcher)
+	chunker := indexer.NewChunker(projectCfg.Chunking.Size, projectCfg.Chunking.Overlap)
+	vectorStore := &projectPrefixStore{
+		store:         sharedStore,
+		workspaceName: ws.Name,
+		projectName:   project.Name,
+		projectPath:   project.Path,
+	}
+	idx := indexer.NewIndexer(project.Path, vectorStore, emb, chunker, scanner, projectCfg.Watch.LastIndexTime)
+	extractor := trace.NewRegexExtractor()
+	symbolStore := trace.NewGOBSymbolStore(config.GetSymbolIndexPath(project.Path))
+	if err := symbolStore.Load(ctx); err != nil {
+		log.Printf("Warning: failed to load symbol index for %s: %v", project.Path, err)
+	}
+
+	tracedLanguages := projectCfg.Trace.EnabledLanguages
+	if len(tracedLanguages) == 0 {
+		tracedLanguages = []string{".go", ".js", ".ts", ".jsx", ".tsx", ".py", ".php", ".lua", ".java", ".cs", ".fs", ".fsx", ".fsi"}
+	}
+
+	return &workspaceProjectRuntime{
+		project:         project,
+		cfg:             projectCfg,
+		idx:             idx,
+		ignoreMatcher:   ignoreMatcher,
+		scanner:         scanner,
+		extractor:       extractor,
+		symbolStore:     symbolStore,
+		vectorStore:     vectorStore,
+		tracedLanguages: tracedLanguages,
+	}, nil
+}
+
+func runWorkspaceProjectInitialScan(ctx context.Context, runtime *workspaceProjectRuntime, isBackgroundChild bool) error {
+	stats, err := runInitialScan(
+		ctx,
+		runtime.idx,
+		runtime.scanner,
+		runtime.extractor,
+		runtime.symbolStore,
+		runtime.tracedLanguages,
+		runtime.cfg.Watch.LastIndexTime,
+		isBackgroundChild,
+		nil,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	if stats.FilesIndexed > 0 || stats.ChunksCreated > 0 {
+		runtime.cfg.Watch.LastIndexTime = time.Now()
+		if err := runtime.cfg.Save(runtime.project.Path); err != nil {
+			log.Printf("Warning: failed to save config for %s: %v", runtime.project.Name, err)
+		}
+	}
+	return nil
+}
+
+func runWorkspaceProjectStartupRefresh(ctx context.Context, ws *config.Workspace, project config.ProjectEntry, emb embedder.Embedder, sharedStore store.VectorStore, isBackgroundChild bool) error {
+	runtime, err := newWorkspaceProjectRuntime(ctx, ws, project, emb, sharedStore)
+	if err != nil {
+		return err
+	}
+	defer runtime.symbolStore.Close()
+	return runWorkspaceProjectInitialScan(ctx, runtime, isBackgroundChild)
+}

--- a/cli/workspace_runtime_test.go
+++ b/cli/workspace_runtime_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yoanbernabeu/grepai/config"
+	"github.com/yoanbernabeu/grepai/store"
+)
+
+func TestRunWorkspaceProjectStartupRefresh_SkipsUnchangedFiles(t *testing.T) {
+	ctx := context.Background()
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644); err != nil {
+		t.Fatalf("failed to seed project file: %v", err)
+	}
+
+	ws := &config.Workspace{Name: "ws"}
+	project := config.ProjectEntry{Name: "proj", Path: projectRoot}
+	sharedStore := store.NewGOBStore(filepath.Join(projectRoot, "workspace-index.gob"))
+
+	firstEmbedder := &countingEmbedder{}
+	if err := runWorkspaceProjectStartupRefresh(ctx, ws, project, firstEmbedder, sharedStore, true); err != nil {
+		t.Fatalf("first startup refresh failed: %v", err)
+	}
+	if firstEmbedder.embedCalls == 0 && firstEmbedder.embedBatchCalls == 0 {
+		t.Fatal("expected first startup refresh to index at least one file")
+	}
+
+	secondEmbedder := &countingEmbedder{}
+	if err := runWorkspaceProjectStartupRefresh(ctx, ws, project, secondEmbedder, sharedStore, true); err != nil {
+		t.Fatalf("second startup refresh failed: %v", err)
+	}
+	if secondEmbedder.embedCalls != 0 || secondEmbedder.embedBatchCalls != 0 {
+		t.Fatalf("expected unchanged second startup refresh to skip embedding, got embed=%d embedBatch=%d", secondEmbedder.embedCalls, secondEmbedder.embedBatchCalls)
+	}
+}

--- a/config/workspace.go
+++ b/config/workspace.go
@@ -233,38 +233,84 @@ func (c *WorkspaceConfig) ListWorkspaces() []string {
 	return names
 }
 
-// FindWorkspaceForPath checks if the given path is within any workspace project.
-// Returns workspace name and workspace config if found, or ("", nil, nil) if no match.
-func FindWorkspaceForPath(targetPath string) (string, *Workspace, error) {
-	cfg, err := LoadWorkspaceConfig()
-	if err != nil {
-		return "", nil, err
-	}
-	if cfg == nil {
-		return "", nil, nil
+// FindWorkspaceProjectForPath checks if the given path is within any workspace
+// project. When multiple projects match, the deepest matching project root wins.
+// Returns workspace name, workspace config, project entry, or zero values when
+// no match exists.
+func (c *WorkspaceConfig) FindWorkspaceProjectForPath(targetPath string) (string, *Workspace, *ProjectEntry, error) {
+	if c == nil || c.Workspaces == nil {
+		return "", nil, nil, nil
 	}
 
-	// Resolve symlinks
 	if resolved, err := filepath.EvalSymlinks(targetPath); err == nil {
 		targetPath = resolved
 	}
+	targetPath = filepath.Clean(targetPath)
 
-	for name, ws := range cfg.Workspaces {
+	var (
+		bestWorkspaceName string
+		bestWorkspace     Workspace
+		bestProject       ProjectEntry
+		bestPathLen       = -1
+	)
+
+	for name, ws := range c.Workspaces {
 		for _, proj := range ws.Projects {
 			projPath := proj.Path
 			if resolved, err := filepath.EvalSymlinks(projPath); err == nil {
 				projPath = resolved
 			}
+			projPath = filepath.Clean(projPath)
+
 			rel, err := filepath.Rel(projPath, targetPath)
 			if err != nil {
 				continue
 			}
-			if !strings.HasPrefix(rel, "..") {
-				wsCopy := ws
-				return name, &wsCopy, nil
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				continue
 			}
+			if len(projPath) <= bestPathLen {
+				continue
+			}
+
+			bestWorkspaceName = name
+			bestWorkspace = ws
+			bestProject = proj
+			bestPathLen = len(projPath)
 		}
 	}
 
-	return "", nil, nil
+	if bestPathLen < 0 {
+		return "", nil, nil, nil
+	}
+
+	wsCopy := bestWorkspace
+	projectCopy := bestProject
+	return bestWorkspaceName, &wsCopy, &projectCopy, nil
+}
+
+// FindWorkspaceProjectForPath loads the global workspace config and resolves
+// the matching workspace/project pair for the given path.
+func FindWorkspaceProjectForPath(targetPath string) (string, *Workspace, *ProjectEntry, error) {
+	cfg, err := LoadWorkspaceConfig()
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if cfg == nil {
+		return "", nil, nil, nil
+	}
+	return cfg.FindWorkspaceProjectForPath(targetPath)
+}
+
+// FindWorkspaceForPath checks if the given path is within any workspace project.
+// Returns workspace name and workspace config if found, or ("", nil, nil) if no match.
+func FindWorkspaceForPath(targetPath string) (string, *Workspace, error) {
+	name, ws, _, err := FindWorkspaceProjectForPath(targetPath)
+	if err != nil {
+		return "", nil, err
+	}
+	if ws == nil {
+		return "", nil, nil
+	}
+	return name, ws, nil
 }

--- a/config/workspace_test.go
+++ b/config/workspace_test.go
@@ -496,6 +496,94 @@ func TestFindWorkspaceForPath(t *testing.T) {
 	})
 }
 
+func TestFindWorkspaceProjectForPath(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "grepai-test-find-project")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cleanup := setTestHomeDir(t, tmpDir)
+	defer cleanup()
+
+	projectA := filepath.Join(tmpDir, "projects", "projectA")
+	nestedProject := filepath.Join(projectA, "nested")
+	deepPath := filepath.Join(nestedProject, "src", "pkg")
+	projectB := filepath.Join(tmpDir, "projects", "projectB")
+	if err := os.MkdirAll(deepPath, 0755); err != nil {
+		t.Fatalf("failed to create deep path: %v", err)
+	}
+	if err := os.MkdirAll(projectB, 0755); err != nil {
+		t.Fatalf("failed to create projectB: %v", err)
+	}
+
+	cfg := DefaultWorkspaceConfig()
+	cfg.AddWorkspace(Workspace{
+		Name:  "ws1",
+		Store: StoreConfig{Backend: "qdrant"},
+		Projects: []ProjectEntry{
+			{Name: "projectA", Path: projectA},
+			{Name: "nested", Path: nestedProject},
+		},
+	})
+	cfg.AddWorkspace(Workspace{
+		Name:  "ws2",
+		Store: StoreConfig{Backend: "postgres"},
+		Projects: []ProjectEntry{
+			{Name: "projectB", Path: projectB},
+		},
+	})
+	if err := SaveWorkspaceConfig(cfg); err != nil {
+		t.Fatalf("failed to save workspace config: %v", err)
+	}
+
+	t.Run("deepest_match_wins", func(t *testing.T) {
+		name, ws, project, err := FindWorkspaceProjectForPath(deepPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ws == nil || project == nil {
+			t.Fatal("expected workspace project match")
+		}
+		if name != "ws1" {
+			t.Fatalf("workspace = %q, want ws1", name)
+		}
+		if project.Name != "nested" {
+			t.Fatalf("project = %q, want nested", project.Name)
+		}
+	})
+
+	t.Run("exact_project_match", func(t *testing.T) {
+		name, ws, project, err := FindWorkspaceProjectForPath(projectB)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ws == nil || project == nil {
+			t.Fatal("expected workspace project match")
+		}
+		if name != "ws2" {
+			t.Fatalf("workspace = %q, want ws2", name)
+		}
+		if project.Name != "projectB" {
+			t.Fatalf("project = %q, want projectB", project.Name)
+		}
+	})
+
+	t.Run("no_match", func(t *testing.T) {
+		unrelated := filepath.Join(tmpDir, "other")
+		if err := os.MkdirAll(unrelated, 0755); err != nil {
+			t.Fatalf("failed to create unrelated path: %v", err)
+		}
+		name, ws, project, err := FindWorkspaceProjectForPath(unrelated)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if name != "" || ws != nil || project != nil {
+			t.Fatalf("expected no match, got (%q, %v, %v)", name, ws, project)
+		}
+	})
+}
+
 func TestGetWorkspaceConfigPath(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "grepai-test")
 	if err != nil {

--- a/docs/src/content/docs/git-worktrees.md
+++ b/docs/src/content/docs/git-worktrees.md
@@ -5,7 +5,7 @@ description: Use grepai seamlessly across git worktrees
 
 ## Git Worktree Support
 
-grepai automatically detects [git worktrees](https://git-scm.com/docs/git-worktree) and provides zero-config setup for linked worktrees. If you work on multiple branches in parallel using `git worktree add`, grepai handles everything transparently.
+grepai automatically detects [git worktrees](https://git-scm.com/docs/git-worktree) and provides zero-config setup for linked worktrees. If you work on multiple branches in parallel using `git worktree add`, search and trace work transparently, and watch can be enabled per worktree or explicitly across all linked worktrees.
 
 ### How It Works
 
@@ -92,6 +92,15 @@ grepai watch
 
 This re-indexes only the files that differ from the copied seed index, keeping your worktree's index up to date.
 
+If you intentionally want a single watcher from the main worktree to include linked worktrees too, opt in explicitly:
+
+```bash
+cd /path/to/main-repo
+grepai watch --all-worktrees
+```
+
+`--all-worktrees` is only needed when you want one watch session to manage the main worktree plus its linked worktrees. The default `grepai watch` command now stays scoped to the current worktree to avoid surprise fanout and re-embedding.
+
 ### What Gets Copied
 
 | File | Purpose | Required |
@@ -108,5 +117,6 @@ If `config.yaml` is missing from the main worktree, auto-init will not proceed.
 |---------|----------|
 | Auto-init doesn't trigger | Verify the main worktree has `.grepai/config.yaml`. Run `grepai init` in the main worktree first. |
 | Search returns stale results | Run `grepai watch` in the linked worktree to update the index with worktree-specific changes. |
+| Main worktree watcher misses linked worktree changes | Use `grepai watch --all-worktrees` from the main worktree, or run `grepai watch` inside the linked worktree you are actively editing. |
 | "not a git repository" error | Ensure `git` is installed and the directory is a valid git worktree. |
 | Want shared indexing | Switch to `postgres` or `qdrant` backend for cross-worktree index sharing. |

--- a/docs/src/content/docs/mcp.md
+++ b/docs/src/content/docs/mcp.md
@@ -144,6 +144,14 @@ When started with the `--workspace` flag, the MCP server automatically injects t
 grepai mcp-serve --workspace my-fullstack
 ```
 
+Full workspace indexing is still an explicit step:
+
+```bash
+grepai watch --workspace my-fullstack
+```
+
+`grepai mcp-serve --workspace ...` serves from that existing workspace index. When it starts inside a specific workspace project, it also performs a local changed-file refresh for that project only before serving. It does not trigger a full workspace re-index on startup.
+
 **How auto-detection works:**
 
 Without `--workspace`, the MCP server resolves its target in this order:
@@ -152,7 +160,7 @@ Without `--workspace`, the MCP server resolves its target in this order:
 2. Walk upward from current directory looking for `.grepai/config.yaml`
 3. Auto-detect workspace by checking if current directory is within a workspace project
 
-With `--workspace`, the server skips auto-detection and uses the specified workspace directly. The `grepai_search` tool will search across all workspace projects without the agent needing to pass `workspace` or `projects` parameters.
+With `--workspace`, the server skips auto-detection and uses the specified workspace directly. The `grepai_search` tool will search across all workspace projects without the agent needing to pass `workspace` or `projects` parameters. If the current directory is inside one of that workspace's projects, grepai also uses that project as the local startup-refresh context.
 
 If no local `.grepai/` project is found but global workspaces are configured, `grepai mcp-serve` can still start without `--workspace`. In that mode, tools can receive `workspace` dynamically in each request.
 

--- a/docs/src/content/docs/workspace.md
+++ b/docs/src/content/docs/workspace.md
@@ -222,6 +222,14 @@ claude mcp add grepai -- grepai mcp-serve --workspace my-fullstack
 
 When `--workspace` is set, the MCP server **auto-injects** the workspace into every search request. AI agents can call `grepai_search` with just a query — no need to pass `workspace` or `projects` parameters. Cross-project search works by default.
 
+Workspace indexing itself remains explicit:
+
+```bash
+grepai watch --workspace my-fullstack
+```
+
+`grepai mcp-serve --workspace my-fullstack` serves from that existing shared index. When started inside one of the workspace's projects, it performs a local changed-file refresh for that project only before serving, instead of re-indexing the entire workspace on startup.
+
 ### Manual Workspace Parameters
 
 Without the `--workspace` flag, agents can still search workspaces by passing parameters explicitly:

--- a/store/qdrant.go
+++ b/store/qdrant.go
@@ -389,8 +389,17 @@ func (s *QdrantStore) GetStats(ctx context.Context) (*IndexStats, error) {
 		return nil, fmt.Errorf("points count %d exceeds maximum int value", pointsCount)
 	}
 
+	scrollResult, err := s.client.Scroll(ctx, &qdrant.ScrollPoints{
+		CollectionName: s.collectionName,
+		Limit:          qdrant.PtrOf(uint32(10000)),
+		WithPayload:    qdrant.NewWithPayloadInclude("file_path"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files for stats: %w", err)
+	}
+
 	stats := &IndexStats{
-		TotalFiles:  0,
+		TotalFiles:  countFilesFromRetrievedPoints(scrollResult),
 		TotalChunks: int(pointsCount),
 		IndexSize:   0,
 		LastUpdated: time.Now(),
@@ -409,8 +418,16 @@ func (s *QdrantStore) ListFilesWithStats(ctx context.Context) ([]FileStats, erro
 		return nil, fmt.Errorf("failed to list files: %w", err)
 	}
 
+	return fileStatsFromRetrievedPoints(scrollResult), nil
+}
+
+func countFilesFromRetrievedPoints(points []*qdrant.RetrievedPoint) int {
+	return len(fileStatsFromRetrievedPoints(points))
+}
+
+func fileStatsFromRetrievedPoints(points []*qdrant.RetrievedPoint) []FileStats {
 	fileStats := make(map[string]*FileStats)
-	for _, point := range scrollResult {
+	for _, point := range points {
 		filePath := ""
 		if val, ok := point.Payload["file_path"]; ok {
 			filePath = val.GetStringValue()
@@ -434,8 +451,7 @@ func (s *QdrantStore) ListFilesWithStats(ctx context.Context) ([]FileStats, erro
 	for _, stat := range fileStats {
 		result = append(result, *stat)
 	}
-
-	return result, nil
+	return result
 }
 
 func (s *QdrantStore) GetChunksForFile(ctx context.Context, filePath string) ([]Chunk, error) {

--- a/store/qdrant.go
+++ b/store/qdrant.go
@@ -21,10 +21,22 @@ func sanitizeUTF8(s string) string {
 }
 
 type QdrantStore struct {
-	client         *qdrant.Client
+	client         qdrantClient
 	collectionName string
 	dimensions     int
 	apiKey         string
+}
+
+type qdrantClient interface {
+	CollectionExists(ctx context.Context, collectionName string) (bool, error)
+	CreateCollection(ctx context.Context, request *qdrant.CreateCollection) error
+	CreateFieldIndex(ctx context.Context, request *qdrant.CreateFieldIndexCollection) (*qdrant.UpdateResult, error)
+	Upsert(ctx context.Context, request *qdrant.UpsertPoints) (*qdrant.UpdateResult, error)
+	Delete(ctx context.Context, request *qdrant.DeletePoints) (*qdrant.UpdateResult, error)
+	Query(ctx context.Context, request *qdrant.QueryPoints) ([]*qdrant.ScoredPoint, error)
+	Scroll(ctx context.Context, request *qdrant.ScrollPoints) ([]*qdrant.RetrievedPoint, error)
+	ScrollAndOffset(ctx context.Context, request *qdrant.ScrollPoints) ([]*qdrant.RetrievedPoint, *qdrant.PointId, error)
+	GetCollectionInfo(ctx context.Context, collectionName string) (*qdrant.CollectionInfo, error)
 }
 
 func parseHost(endpoint string) string {
@@ -384,12 +396,15 @@ func (s *QdrantStore) GetStats(ctx context.Context) (*IndexStats, error) {
 		return nil, fmt.Errorf("failed to get collection info: %w", err)
 	}
 
-	pointsCount := *collectionInfo.PointsCount
+	pointsCount := uint64(0)
+	if collectionInfo.PointsCount != nil {
+		pointsCount = *collectionInfo.PointsCount
+	}
 	if pointsCount > uint64(^uint(0)>>1) {
 		return nil, fmt.Errorf("points count %d exceeds maximum int value", pointsCount)
 	}
 
-	scrollResult, err := s.client.Scroll(ctx, &qdrant.ScrollPoints{
+	scrollResult, err := s.scrollAll(ctx, &qdrant.ScrollPoints{
 		CollectionName: s.collectionName,
 		Limit:          qdrant.PtrOf(uint32(10000)),
 		WithPayload:    qdrant.NewWithPayloadInclude("file_path"),
@@ -409,7 +424,7 @@ func (s *QdrantStore) GetStats(ctx context.Context) (*IndexStats, error) {
 }
 
 func (s *QdrantStore) ListFilesWithStats(ctx context.Context) ([]FileStats, error) {
-	scrollResult, err := s.client.Scroll(ctx, &qdrant.ScrollPoints{
+	scrollResult, err := s.scrollAll(ctx, &qdrant.ScrollPoints{
 		CollectionName: s.collectionName,
 		Limit:          qdrant.PtrOf(uint32(10000)),
 		WithPayload:    qdrant.NewWithPayloadInclude("file_path", "start_line", "end_line"),
@@ -419,6 +434,47 @@ func (s *QdrantStore) ListFilesWithStats(ctx context.Context) ([]FileStats, erro
 	}
 
 	return fileStatsFromRetrievedPoints(scrollResult), nil
+}
+
+func (s *QdrantStore) scrollAll(ctx context.Context, req *qdrant.ScrollPoints) ([]*qdrant.RetrievedPoint, error) {
+	var (
+		allPoints []*qdrant.RetrievedPoint
+		offset    *qdrant.PointId
+	)
+
+	for {
+		reqCopy := cloneScrollPointsRequest(req)
+		reqCopy.Offset = offset
+
+		points, nextOffset, err := s.client.ScrollAndOffset(ctx, reqCopy)
+		if err != nil {
+			return nil, err
+		}
+		allPoints = append(allPoints, points...)
+		if nextOffset == nil || len(points) == 0 {
+			return allPoints, nil
+		}
+		offset = nextOffset
+	}
+}
+
+func cloneScrollPointsRequest(req *qdrant.ScrollPoints) *qdrant.ScrollPoints {
+	if req == nil {
+		return nil
+	}
+
+	return &qdrant.ScrollPoints{
+		CollectionName:   req.CollectionName,
+		Filter:           req.Filter,
+		Offset:           req.Offset,
+		Limit:            req.Limit,
+		WithPayload:      req.WithPayload,
+		WithVectors:      req.WithVectors,
+		ReadConsistency:  req.ReadConsistency,
+		ShardKeySelector: req.ShardKeySelector,
+		OrderBy:          req.OrderBy,
+		Timeout:          req.Timeout,
+	}
 }
 
 func countFilesFromRetrievedPoints(points []*qdrant.RetrievedPoint) int {

--- a/store/qdrant.go
+++ b/store/qdrant.go
@@ -32,6 +32,7 @@ type qdrantClient interface {
 	CreateCollection(ctx context.Context, request *qdrant.CreateCollection) error
 	CreateFieldIndex(ctx context.Context, request *qdrant.CreateFieldIndexCollection) (*qdrant.UpdateResult, error)
 	Upsert(ctx context.Context, request *qdrant.UpsertPoints) (*qdrant.UpdateResult, error)
+	SetPayload(ctx context.Context, request *qdrant.SetPayloadPoints) (*qdrant.UpdateResult, error)
 	Delete(ctx context.Context, request *qdrant.DeletePoints) (*qdrant.UpdateResult, error)
 	Query(ctx context.Context, request *qdrant.QueryPoints) ([]*qdrant.ScoredPoint, error)
 	Scroll(ctx context.Context, request *qdrant.ScrollPoints) ([]*qdrant.RetrievedPoint, error)
@@ -107,11 +108,16 @@ func (s *QdrantStore) ensureCollection(ctx context.Context) error {
 		}
 	}
 
-	// Create field index for content_hash to enable efficient lookups.
-	// Error is intentionally ignored because the index may already exist.
+	// Create field indexes for efficient filtered lookups.
+	// Errors are intentionally ignored because the indexes may already exist.
 	_, _ = s.client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
 		CollectionName: s.collectionName,
 		FieldName:      "content_hash",
+		FieldType:      qdrant.PtrOf(qdrant.FieldType_FieldTypeKeyword),
+	})
+	_, _ = s.client.CreateFieldIndex(ctx, &qdrant.CreateFieldIndexCollection{
+		CollectionName: s.collectionName,
+		FieldName:      "file_path",
 		FieldType:      qdrant.PtrOf(qdrant.FieldType_FieldTypeKeyword),
 	})
 
@@ -327,7 +333,7 @@ func (s *QdrantStore) GetDocument(ctx context.Context, filePath string) (*Docume
 		CollectionName: s.collectionName,
 		Filter:         filter,
 		Limit:          qdrant.PtrOf(uint32(1)),
-		WithPayload:    qdrant.NewWithPayloadInclude("chunk_ids"),
+		WithPayload:    qdrant.NewWithPayloadInclude("doc_hash"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get document: %w", err)
@@ -338,23 +344,61 @@ func (s *QdrantStore) GetDocument(ctx context.Context, filePath string) (*Docume
 	}
 
 	doc := &Document{
-		Path:     filePath,
-		ChunkIDs: []string{},
+		Path: filePath,
 	}
+
+	if val, ok := scrollResult[0].Payload["doc_hash"]; ok && val.GetStringValue() != "" {
+		doc.Hash = val.GetStringValue()
+		// Sentinel value: the indexer only checks len(ChunkIDs) > 0.
+		// Fetching all chunk IDs would require scrolling the entire file,
+		// so we use a single placeholder to signal that chunks exist.
+		doc.ChunkIDs = []string{"_"}
+	}
+	// Legacy chunks without doc_hash return an empty Hash and nil ChunkIDs,
+	// which causes the indexer to re-index the file and write doc_hash.
 
 	return doc, nil
 }
 
 func (s *QdrantStore) SaveDocument(ctx context.Context, doc Document) error {
+	if doc.Hash == "" {
+		return nil
+	}
+
+	docHashVal, err := qdrant.NewValue(doc.Hash)
+	if err != nil {
+		return fmt.Errorf("failed to create doc_hash value: %w", err)
+	}
+
+	filter := &qdrant.Filter{
+		Must: []*qdrant.Condition{
+			qdrant.NewMatch("file_path", doc.Path),
+		},
+	}
+
+	_, err = s.client.SetPayload(ctx, &qdrant.SetPayloadPoints{
+		CollectionName: s.collectionName,
+		Payload: map[string]*qdrant.Value{
+			"doc_hash": docHashVal,
+		},
+		PointsSelector: qdrant.NewPointsSelectorFilter(filter),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set doc_hash payload: %w", err)
+	}
+
 	return nil
 }
 
+// DeleteDocument is a no-op for Qdrant because document metadata (doc_hash)
+// is stored as payload on chunk points. RemoveFile always calls DeleteByFile
+// first, which deletes all chunk points, so there is nothing left to clean up.
 func (s *QdrantStore) DeleteDocument(ctx context.Context, filePath string) error {
 	return nil
 }
 
 func (s *QdrantStore) ListDocuments(ctx context.Context) ([]string, error) {
-	scrollResult, err := s.client.Scroll(ctx, &qdrant.ScrollPoints{
+	points, err := s.scrollAll(ctx, &qdrant.ScrollPoints{
 		CollectionName: s.collectionName,
 		Limit:          qdrant.PtrOf(uint32(1000)),
 		WithPayload:    qdrant.NewWithPayloadInclude("file_path"),
@@ -364,7 +408,7 @@ func (s *QdrantStore) ListDocuments(ctx context.Context) ([]string, error) {
 	}
 
 	pathsMap := make(map[string]bool)
-	for _, point := range scrollResult {
+	for _, point := range points {
 		if val, ok := point.Payload["file_path"]; ok {
 			pathsMap[val.GetStringValue()] = true
 		}
@@ -543,9 +587,9 @@ func (s *QdrantStore) GetChunksForFile(ctx context.Context, filePath string) ([]
 }
 
 func (s *QdrantStore) GetAllChunks(ctx context.Context) ([]Chunk, error) {
-	scrollResult, err := s.client.Scroll(ctx, &qdrant.ScrollPoints{
+	points, err := s.scrollAll(ctx, &qdrant.ScrollPoints{
 		CollectionName: s.collectionName,
-		Limit:          qdrant.PtrOf(uint32(100000)),
+		Limit:          qdrant.PtrOf(uint32(1000)),
 		WithPayload:    qdrant.NewWithPayloadInclude("file_path", "start_line", "end_line", "content", "hash", "updated_at"),
 		WithVectors:    qdrant.NewWithVectors(true),
 	})
@@ -553,8 +597,8 @@ func (s *QdrantStore) GetAllChunks(ctx context.Context) ([]Chunk, error) {
 		return nil, fmt.Errorf("failed to get all chunks: %w", err)
 	}
 
-	chunks := make([]Chunk, 0, len(scrollResult))
-	for _, point := range scrollResult {
+	chunks := make([]Chunk, 0, len(points))
+	for _, point := range points {
 		chunk := s.parseChunkPayload(point.Payload)
 		if point.Vectors != nil && point.Vectors.GetVector() != nil {
 			if dense := point.Vectors.GetVector().GetDense(); dense != nil {

--- a/store/qdrant_test.go
+++ b/store/qdrant_test.go
@@ -447,3 +447,47 @@ func TestQdrantStore_ConfigurationVariants(t *testing.T) {
 		})
 	}
 }
+
+func TestFileStatsFromRetrievedPoints(t *testing.T) {
+	points := []*qdrant.RetrievedPoint{
+		{
+			Payload: map[string]*qdrant.Value{
+				"file_path": mustCreateValue(t, "a.go"),
+			},
+		},
+		{
+			Payload: map[string]*qdrant.Value{
+				"file_path": mustCreateValue(t, "a.go"),
+			},
+		},
+		{
+			Payload: map[string]*qdrant.Value{
+				"file_path": mustCreateValue(t, "b.go"),
+			},
+		},
+		{
+			Payload: map[string]*qdrant.Value{
+				"other": mustCreateValue(t, "ignored"),
+			},
+		},
+	}
+
+	stats := fileStatsFromRetrievedPoints(points)
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(stats))
+	}
+	if countFilesFromRetrievedPoints(points) != 2 {
+		t.Fatalf("countFilesFromRetrievedPoints() = %d, want 2", countFilesFromRetrievedPoints(points))
+	}
+
+	counts := map[string]int{}
+	for _, stat := range stats {
+		counts[stat.Path] = stat.ChunkCount
+	}
+	if counts["a.go"] != 2 {
+		t.Fatalf("a.go chunk count = %d, want 2", counts["a.go"])
+	}
+	if counts["b.go"] != 1 {
+		t.Fatalf("b.go chunk count = %d, want 1", counts["b.go"])
+	}
+}

--- a/store/qdrant_test.go
+++ b/store/qdrant_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -16,6 +17,70 @@ func mustCreateValue(t *testing.T, value interface{}) *qdrant.Value {
 		t.Fatalf("failed to create qdrant value: %v", err)
 	}
 	return val
+}
+
+type mockQdrantClient struct {
+	collectionInfo       *qdrant.CollectionInfo
+	getCollectionInfoErr error
+	scrollPages          [][]*qdrant.RetrievedPoint
+	scrollOffsets        []*qdrant.PointId
+	scrollAndOffsetErr   error
+	scrollRequests       []*qdrant.ScrollPoints
+}
+
+func (m *mockQdrantClient) CollectionExists(ctx context.Context, collectionName string) (bool, error) {
+	panic("unexpected CollectionExists call")
+}
+
+func (m *mockQdrantClient) CreateCollection(ctx context.Context, request *qdrant.CreateCollection) error {
+	panic("unexpected CreateCollection call")
+}
+
+func (m *mockQdrantClient) CreateFieldIndex(ctx context.Context, request *qdrant.CreateFieldIndexCollection) (*qdrant.UpdateResult, error) {
+	panic("unexpected CreateFieldIndex call")
+}
+
+func (m *mockQdrantClient) Upsert(ctx context.Context, request *qdrant.UpsertPoints) (*qdrant.UpdateResult, error) {
+	panic("unexpected Upsert call")
+}
+
+func (m *mockQdrantClient) Delete(ctx context.Context, request *qdrant.DeletePoints) (*qdrant.UpdateResult, error) {
+	panic("unexpected Delete call")
+}
+
+func (m *mockQdrantClient) Query(ctx context.Context, request *qdrant.QueryPoints) ([]*qdrant.ScoredPoint, error) {
+	panic("unexpected Query call")
+}
+
+func (m *mockQdrantClient) Scroll(ctx context.Context, request *qdrant.ScrollPoints) ([]*qdrant.RetrievedPoint, error) {
+	panic("unexpected Scroll call")
+}
+
+func (m *mockQdrantClient) ScrollAndOffset(ctx context.Context, request *qdrant.ScrollPoints) ([]*qdrant.RetrievedPoint, *qdrant.PointId, error) {
+	m.scrollRequests = append(m.scrollRequests, cloneScrollPointsRequest(request))
+
+	if m.scrollAndOffsetErr != nil {
+		return nil, nil, m.scrollAndOffsetErr
+	}
+
+	pageIndex := len(m.scrollRequests) - 1
+	if pageIndex >= len(m.scrollPages) {
+		return nil, nil, nil
+	}
+
+	var nextOffset *qdrant.PointId
+	if pageIndex < len(m.scrollOffsets) {
+		nextOffset = m.scrollOffsets[pageIndex]
+	}
+
+	return m.scrollPages[pageIndex], nextOffset, nil
+}
+
+func (m *mockQdrantClient) GetCollectionInfo(ctx context.Context, collectionName string) (*qdrant.CollectionInfo, error) {
+	if m.getCollectionInfoErr != nil {
+		return nil, m.getCollectionInfoErr
+	}
+	return m.collectionInfo, nil
 }
 
 // TestSanitizeCollectionName tests the exported SanitizeCollectionName function
@@ -489,5 +554,111 @@ func TestFileStatsFromRetrievedPoints(t *testing.T) {
 	}
 	if counts["b.go"] != 1 {
 		t.Fatalf("b.go chunk count = %d, want 1", counts["b.go"])
+	}
+}
+
+func TestQdrantStore_GetStats_PaginatesScrollResults(t *testing.T) {
+	pointsCount := uint64(3)
+	client := &mockQdrantClient{
+		collectionInfo: &qdrant.CollectionInfo{PointsCount: &pointsCount},
+		scrollPages: [][]*qdrant.RetrievedPoint{
+			{
+				{Payload: map[string]*qdrant.Value{"file_path": mustCreateValue(t, "a.go")}},
+				{Payload: map[string]*qdrant.Value{"file_path": mustCreateValue(t, "a.go")}},
+			},
+			{
+				{Payload: map[string]*qdrant.Value{"file_path": mustCreateValue(t, "b.go")}},
+			},
+		},
+		scrollOffsets: []*qdrant.PointId{
+			qdrant.NewID("next-page"),
+			nil,
+		},
+	}
+	store := &QdrantStore{
+		client:         client,
+		collectionName: "test-collection",
+	}
+
+	stats, err := store.GetStats(context.Background())
+	if err != nil {
+		t.Fatalf("GetStats failed: %v", err)
+	}
+
+	if stats.TotalChunks != 3 {
+		t.Fatalf("TotalChunks = %d, want 3", stats.TotalChunks)
+	}
+	if stats.TotalFiles != 2 {
+		t.Fatalf("TotalFiles = %d, want 2", stats.TotalFiles)
+	}
+	if len(client.scrollRequests) != 2 {
+		t.Fatalf("scroll request count = %d, want 2", len(client.scrollRequests))
+	}
+	if client.scrollRequests[0].Offset != nil {
+		t.Fatal("expected first scroll request to have no offset")
+	}
+	if client.scrollRequests[1].Offset == nil {
+		t.Fatal("expected second scroll request to carry pagination offset")
+	}
+}
+
+func TestQdrantStore_ListFilesWithStats_PaginatesScrollResults(t *testing.T) {
+	client := &mockQdrantClient{
+		scrollPages: [][]*qdrant.RetrievedPoint{
+			{
+				{Payload: map[string]*qdrant.Value{"file_path": mustCreateValue(t, "a.go")}},
+				{Payload: map[string]*qdrant.Value{"file_path": mustCreateValue(t, "a.go")}},
+			},
+			{
+				{Payload: map[string]*qdrant.Value{"file_path": mustCreateValue(t, "b.go")}},
+			},
+		},
+		scrollOffsets: []*qdrant.PointId{
+			qdrant.NewID("next-page"),
+			nil,
+		},
+	}
+	store := &QdrantStore{
+		client:         client,
+		collectionName: "test-collection",
+	}
+
+	files, err := store.ListFilesWithStats(context.Background())
+	if err != nil {
+		t.Fatalf("ListFilesWithStats failed: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Fatalf("file count = %d, want 2", len(files))
+	}
+
+	counts := map[string]int{}
+	for _, file := range files {
+		counts[file.Path] = file.ChunkCount
+	}
+	if counts["a.go"] != 2 {
+		t.Fatalf("a.go chunk count = %d, want 2", counts["a.go"])
+	}
+	if counts["b.go"] != 1 {
+		t.Fatalf("b.go chunk count = %d, want 1", counts["b.go"])
+	}
+	if len(client.scrollRequests) != 2 {
+		t.Fatalf("scroll request count = %d, want 2", len(client.scrollRequests))
+	}
+}
+
+func TestQdrantStore_GetStats_PropagatesScrollError(t *testing.T) {
+	pointsCount := uint64(1)
+	store := &QdrantStore{
+		client: &mockQdrantClient{
+			collectionInfo:     &qdrant.CollectionInfo{PointsCount: &pointsCount},
+			scrollAndOffsetErr: errors.New("scroll failed"),
+		},
+		collectionName: "test-collection",
+	}
+
+	_, err := store.GetStats(context.Background())
+	if err == nil || err.Error() != "failed to list files for stats: scroll failed" {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/store/qdrant_test.go
+++ b/store/qdrant_test.go
@@ -26,6 +26,10 @@ type mockQdrantClient struct {
 	scrollOffsets        []*qdrant.PointId
 	scrollAndOffsetErr   error
 	scrollRequests       []*qdrant.ScrollPoints
+	scrollResult         []*qdrant.RetrievedPoint
+	scrollErr            error
+	setPayloadRequests   []*qdrant.SetPayloadPoints
+	setPayloadErr        error
 }
 
 func (m *mockQdrantClient) CollectionExists(ctx context.Context, collectionName string) (bool, error) {
@@ -44,6 +48,11 @@ func (m *mockQdrantClient) Upsert(ctx context.Context, request *qdrant.UpsertPoi
 	panic("unexpected Upsert call")
 }
 
+func (m *mockQdrantClient) SetPayload(ctx context.Context, request *qdrant.SetPayloadPoints) (*qdrant.UpdateResult, error) {
+	m.setPayloadRequests = append(m.setPayloadRequests, request)
+	return nil, m.setPayloadErr
+}
+
 func (m *mockQdrantClient) Delete(ctx context.Context, request *qdrant.DeletePoints) (*qdrant.UpdateResult, error) {
 	panic("unexpected Delete call")
 }
@@ -53,7 +62,10 @@ func (m *mockQdrantClient) Query(ctx context.Context, request *qdrant.QueryPoint
 }
 
 func (m *mockQdrantClient) Scroll(ctx context.Context, request *qdrant.ScrollPoints) ([]*qdrant.RetrievedPoint, error) {
-	panic("unexpected Scroll call")
+	if m.scrollErr != nil {
+		return nil, m.scrollErr
+	}
+	return m.scrollResult, nil
 }
 
 func (m *mockQdrantClient) ScrollAndOffset(ctx context.Context, request *qdrant.ScrollPoints) ([]*qdrant.RetrievedPoint, *qdrant.PointId, error) {
@@ -660,5 +672,147 @@ func TestQdrantStore_GetStats_PropagatesScrollError(t *testing.T) {
 	_, err := store.GetStats(context.Background())
 	if err == nil || err.Error() != "failed to list files for stats: scroll failed" {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestQdrantStore_GetDocument_WithDocHash(t *testing.T) {
+	store := &QdrantStore{
+		client: &mockQdrantClient{
+			scrollResult: []*qdrant.RetrievedPoint{
+				{
+					Payload: map[string]*qdrant.Value{
+						"doc_hash": mustCreateValue(t, "deadbeef"),
+					},
+				},
+			},
+		},
+		collectionName: "test-collection",
+	}
+
+	doc, err := store.GetDocument(context.Background(), "main.go")
+	if err != nil {
+		t.Fatalf("GetDocument failed: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil document")
+	}
+	if doc.Hash != "deadbeef" {
+		t.Fatalf("expected Hash %q, got %q", "deadbeef", doc.Hash)
+	}
+	if len(doc.ChunkIDs) == 0 {
+		t.Fatal("expected non-empty ChunkIDs sentinel")
+	}
+}
+
+func TestQdrantStore_GetDocument_LegacyChunkNoDocHash(t *testing.T) {
+	store := &QdrantStore{
+		client: &mockQdrantClient{
+			scrollResult: []*qdrant.RetrievedPoint{
+				{
+					Payload: map[string]*qdrant.Value{
+						"file_path": mustCreateValue(t, "main.go"),
+					},
+				},
+			},
+		},
+		collectionName: "test-collection",
+	}
+
+	doc, err := store.GetDocument(context.Background(), "main.go")
+	if err != nil {
+		t.Fatalf("GetDocument failed: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil document (file exists but is legacy)")
+	}
+	if doc.Hash != "" {
+		t.Fatalf("expected empty Hash for legacy chunk, got %q", doc.Hash)
+	}
+	if len(doc.ChunkIDs) != 0 {
+		t.Fatalf("expected empty ChunkIDs for legacy chunk, got %v", doc.ChunkIDs)
+	}
+}
+
+func TestQdrantStore_GetDocument_NotFound(t *testing.T) {
+	store := &QdrantStore{
+		client:         &mockQdrantClient{},
+		collectionName: "test-collection",
+	}
+
+	doc, err := store.GetDocument(context.Background(), "missing.go")
+	if err != nil {
+		t.Fatalf("GetDocument failed: %v", err)
+	}
+	if doc != nil {
+		t.Fatalf("expected nil document for missing file, got %+v", doc)
+	}
+}
+
+func TestQdrantStore_SaveDocument_SetsPayload(t *testing.T) {
+	client := &mockQdrantClient{}
+	store := &QdrantStore{
+		client:         client,
+		collectionName: "test-collection",
+	}
+
+	err := store.SaveDocument(context.Background(), Document{Path: "main.go", Hash: "abc123"})
+	if err != nil {
+		t.Fatalf("SaveDocument failed: %v", err)
+	}
+	if len(client.setPayloadRequests) != 1 {
+		t.Fatalf("expected 1 SetPayload call, got %d", len(client.setPayloadRequests))
+	}
+	req := client.setPayloadRequests[0]
+	if val, ok := req.Payload["doc_hash"]; !ok || val.GetStringValue() != "abc123" {
+		t.Fatalf("expected doc_hash=abc123 in payload, got %v", req.Payload)
+	}
+}
+
+func TestQdrantStore_SaveDocument_EmptyHashIsNoop(t *testing.T) {
+	client := &mockQdrantClient{}
+	store := &QdrantStore{
+		client:         client,
+		collectionName: "test-collection",
+	}
+
+	err := store.SaveDocument(context.Background(), Document{Path: "main.go", Hash: ""})
+	if err != nil {
+		t.Fatalf("SaveDocument failed: %v", err)
+	}
+	if len(client.setPayloadRequests) != 0 {
+		t.Fatalf("expected no SetPayload call for empty hash, got %d", len(client.setPayloadRequests))
+	}
+}
+
+func TestQdrantStore_ListDocuments_Paginates(t *testing.T) {
+	client := &mockQdrantClient{
+		scrollPages: [][]*qdrant.RetrievedPoint{
+			{
+				{Payload: map[string]*qdrant.Value{"file_path": mustCreateValue(t, "a.go")}},
+				{Payload: map[string]*qdrant.Value{"file_path": mustCreateValue(t, "a.go")}},
+			},
+			{
+				{Payload: map[string]*qdrant.Value{"file_path": mustCreateValue(t, "b.go")}},
+			},
+		},
+		scrollOffsets: []*qdrant.PointId{
+			qdrant.NewID("next-page"),
+			nil,
+		},
+	}
+	store := &QdrantStore{
+		client:         client,
+		collectionName: "test-collection",
+	}
+
+	paths, err := store.ListDocuments(context.Background())
+	if err != nil {
+		t.Fatalf("ListDocuments failed: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 unique paths, got %d: %v", len(paths), paths)
+	}
+	if len(client.scrollRequests) != 2 {
+		t.Fatalf("expected 2 scroll requests (pagination), got %d", len(client.scrollRequests))
 	}
 }


### PR DESCRIPTION
## Summary

- Qdrant backend now tracks document hashes (`doc_hash`) as payload on chunk points, enabling `grepai watch` to skip unchanged files on restart instead of re-embedding the entire codebase
- Adds `file_path` field index for efficient filtered lookups used by `SetPayload` and `GetDocument`
- Switches `GetAllChunks` and `ListDocuments` to paginated `scrollAll` for correct behavior on large collections
- Legacy indexes (chunks without `doc_hash`) are migrated transparently on first run via a one-time re-index

## Design

Instead of a separate document collection, `doc_hash` is stored directly on existing chunk points via `SetPayload`. `GetDocument` reads it from any single chunk of the file and returns a sentinel `ChunkIDs` slice to avoid expensive full-file scrolls. This keeps the Qdrant schema flat and avoids cross-collection coordination.

## Test plan

- [x] `TestQdrantStore_GetDocument_WithDocHash` — verifies hash and sentinel ChunkIDs are returned
- [x] `TestQdrantStore_GetDocument_LegacyChunkNoDocHash` — verifies legacy chunks trigger re-index
- [x] `TestQdrantStore_GetDocument_NotFound` — verifies nil return for missing files
- [x] `TestQdrantStore_SaveDocument_SetsPayload` — verifies SetPayload is called with correct doc_hash
- [x] `TestQdrantStore_SaveDocument_EmptyHashIsNoop` — verifies no-op for empty hash
- [x] `TestQdrantStore_ListDocuments_Paginates` — verifies pagination via scrollAll
- [x] Full test suite passes (`go test ./...`)

## Note
This is on top of #196