### PR TITLE
fix(rpg): add Graph mutex to prevent concurrent map access crash

### DIFF
--- a/rpg/indexer.go
+++ b/rpg/indexer.go
@@ -82,9 +82,7 @@ func (idx *RPGEncoder) BuildFull(ctx context.Context, symbolStore trace.SymbolSt
 	graph := idx.store.GetGraph()
 
 	// Clear existing graph data in-place (not reassigning the pointer)
-	graph.Nodes = make(map[string]*Node)
-	graph.Edges = make([]*Edge, 0)
-	graph.RebuildIndexes()
+	graph.Reset()
 
 	// Get all documents from vector store to know which files to process
 	docs, err := vectorStore.ListDocuments(ctx)

--- a/rpg/model.go
+++ b/rpg/model.go
@@ -3,6 +3,7 @@ package rpg
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -67,9 +68,15 @@ type Edge struct {
 }
 
 // Graph is the in-memory RPG graph with fast lookup indexes.
+// All public methods are safe for concurrent use.
 type Graph struct {
 	Nodes map[string]*Node `json:"nodes"`
 	Edges []*Edge          `json:"edges"`
+
+	// mu protects all fields from concurrent access.
+	// Callers that need to read Nodes/Edges directly (e.g. for serialization)
+	// must acquire mu.RLock() for the duration of the read.
+	mu sync.RWMutex
 
 	// Indexes for fast lookup (not serialized)
 	byKind        map[NodeKind][]*Node
@@ -107,6 +114,8 @@ func NewGraph() *Graph {
 //
 // TODO: consider map[string]int index for O(1) stale-entry removal during bulk operations
 func (g *Graph) AddNode(n *Node) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	// If node already exists, remove old index entries first
 	if old, exists := g.Nodes[n.ID]; exists {
 		if nodes, ok := g.byKind[old.Kind]; ok {
@@ -150,6 +159,8 @@ func (g *Graph) AddNode(n *Node) {
 
 // RemoveNode removes a node and all its edges, updating indexes.
 func (g *Graph) RemoveNode(id string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	n, ok := g.Nodes[id]
 	if !ok {
 		return
@@ -239,6 +250,8 @@ func (g *Graph) RemoveNode(id string) {
 
 // AddEdge adds an edge and updates adjacency indexes.
 func (g *Graph) AddEdge(e *Edge) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	g.Edges = append(g.Edges, e)
 	g.adjForward[e.From] = append(g.adjForward[e.From], e)
 	g.adjReverse[e.To] = append(g.adjReverse[e.To], e)
@@ -246,6 +259,8 @@ func (g *Graph) AddEdge(e *Edge) {
 
 // RemoveEdgesBetween removes all edges between two nodes.
 func (g *Graph) RemoveEdgesBetween(from, to string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	// Remove from main edge list
 	filtered := make([]*Edge, 0, len(g.Edges))
 	for _, e := range g.Edges {
@@ -288,6 +303,8 @@ func (g *Graph) RemoveEdgesBetween(from, to string) {
 
 // RemoveEdgesBetweenOfType removes edges of a specific type between two nodes.
 func (g *Graph) RemoveEdgesBetweenOfType(from, to string, edgeType EdgeType) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	// Remove from main edge list
 	filtered := make([]*Edge, 0, len(g.Edges))
 	for _, e := range g.Edges {
@@ -329,32 +346,50 @@ func (g *Graph) RemoveEdgesBetweenOfType(from, to string, edgeType EdgeType) {
 }
 
 // RemoveEdgesIf removes edges that match the predicate and rebuilds edge indexes.
+// The predicate is evaluated without holding the graph lock so it may safely call
+// other Graph methods. Edges added or removed concurrently during predicate
+// evaluation are handled conservatively: only edges present at snapshot time that
+// match the predicate are removed.
 func (g *Graph) RemoveEdgesIf(predicate func(*Edge) bool) {
 	if predicate == nil {
 		return
 	}
 
-	filtered := make([]*Edge, 0, len(g.Edges))
-	removed := false
-	for _, e := range g.Edges {
-		if predicate(e) {
-			removed = true
-			continue
-		}
-		filtered = append(filtered, e)
-	}
+	// Snapshot edge list under read lock so the predicate can call graph methods.
+	g.mu.RLock()
+	snapshot := make([]*Edge, len(g.Edges))
+	copy(snapshot, g.Edges)
+	g.mu.RUnlock()
 
-	if !removed {
+	// Evaluate predicate without holding the lock.
+	toRemove := make(map[*Edge]bool)
+	for _, e := range snapshot {
+		if predicate(e) {
+			toRemove[e] = true
+		}
+	}
+	if len(toRemove) == 0 {
 		return
 	}
 
+	// Apply the filter and rebuild indexes under write lock.
+	g.mu.Lock()
+	filtered := make([]*Edge, 0, len(g.Edges))
+	for _, e := range g.Edges {
+		if !toRemove[e] {
+			filtered = append(filtered, e)
+		}
+	}
 	g.Edges = filtered
-	g.RebuildIndexes()
+	g.rebuildIndexesLocked()
+	g.mu.Unlock()
 }
 
 // NodePath returns the file path for a node ID when present.
 func (g *Graph) NodePath(id string) (string, bool) {
-	n := g.GetNode(id)
+	g.mu.RLock()
+	n := g.Nodes[id]
+	g.mu.RUnlock()
 	if n == nil || n.Path == "" {
 		return "", false
 	}
@@ -363,31 +398,44 @@ func (g *Graph) NodePath(id string) (string, bool) {
 
 // GetNode returns a node by ID.
 func (g *Graph) GetNode(id string) *Node {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 	return g.Nodes[id]
 }
 
 // GetNodesByKind returns all nodes of a given kind.
 func (g *Graph) GetNodesByKind(kind NodeKind) []*Node {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 	return g.byKind[kind]
 }
 
 // GetNodesByFile returns all nodes for a given file path.
 func (g *Graph) GetNodesByFile(path string) []*Node {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 	return g.byFile[path]
 }
 
 // GetOutgoing returns all outgoing edges from a node.
 func (g *Graph) GetOutgoing(nodeID string) []*Edge {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 	return g.adjForward[nodeID]
 }
 
 // GetIncoming returns all incoming edges to a node.
 func (g *Graph) GetIncoming(nodeID string) []*Edge {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
 	return g.adjReverse[nodeID]
 }
 
 // GetNeighbors returns neighbor node IDs in a given direction ("forward", "reverse", "both").
 func (g *Graph) GetNeighbors(nodeID string, direction string) []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
 	seen := make(map[string]bool)
 	var result []string
 
@@ -412,9 +460,25 @@ func (g *Graph) GetNeighbors(nodeID string, direction string) []string {
 	return result
 }
 
+// Reset clears all graph data and rebuilds empty indexes atomically.
+func (g *Graph) Reset() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.Nodes = make(map[string]*Node)
+	g.Edges = make([]*Edge, 0)
+	g.rebuildIndexesLocked()
+}
+
 // RebuildIndexes rebuilds all in-memory indexes from Nodes and Edges.
 // Called after deserialization.
 func (g *Graph) RebuildIndexes() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.rebuildIndexesLocked()
+}
+
+// rebuildIndexesLocked rebuilds indexes assuming the caller already holds g.mu.
+func (g *Graph) rebuildIndexesLocked() {
 	g.byKind = make(map[NodeKind][]*Node)
 	g.byFile = make(map[string][]*Node)
 	g.byFeaturePath = make(map[string]*Node)
@@ -441,6 +505,9 @@ func (g *Graph) RebuildIndexes() {
 
 // Stats returns basic graph statistics.
 func (g *Graph) Stats() GraphStats {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
 	nodesByKind := make(map[NodeKind]int)
 	for _, n := range g.Nodes {
 		nodesByKind[n.Kind]++

--- a/rpg/store_gob.go
+++ b/rpg/store_gob.go
@@ -76,26 +76,25 @@ func (s *GOBRPGStore) loadUnlocked() error {
 
 	if data.Version != CurrentRPGIndexVersion {
 		hasData := len(data.Nodes) > 0 || len(data.Edges) > 0
-		s.graph.Nodes = make(map[string]*Node)
-		s.graph.Edges = make([]*Edge, 0)
-		s.graph.RebuildIndexes()
+		s.graph.Reset()
 		if hasData {
 			return ErrRPGIndexOutdated
 		}
 		return nil
 	}
 
+	if data.Nodes == nil {
+		data.Nodes = make(map[string]*Node)
+	}
+	if data.Edges == nil {
+		data.Edges = make([]*Edge, 0)
+	}
+
+	s.graph.mu.Lock()
 	s.graph.Nodes = data.Nodes
 	s.graph.Edges = data.Edges
-
-	if s.graph.Nodes == nil {
-		s.graph.Nodes = make(map[string]*Node)
-	}
-	if s.graph.Edges == nil {
-		s.graph.Edges = make([]*Edge, 0)
-	}
-
-	s.graph.RebuildIndexes()
+	s.graph.rebuildIndexesLocked()
+	s.graph.mu.Unlock()
 
 	return nil
 }
@@ -129,10 +128,21 @@ func (s *GOBRPGStore) Persist(ctx context.Context) error {
 }
 
 func (s *GOBRPGStore) persistUnlocked() error {
+	// Snapshot Nodes and Edges under the graph's read lock so no concurrent
+	// mutation can modify them while gob iterates the maps/slices.
+	s.graph.mu.RLock()
+	nodes := make(map[string]*Node, len(s.graph.Nodes))
+	for k, v := range s.graph.Nodes {
+		nodes[k] = v
+	}
+	edges := make([]*Edge, len(s.graph.Edges))
+	copy(edges, s.graph.Edges)
+	s.graph.mu.RUnlock()
+
 	data := gobRPGData{
 		Version: CurrentRPGIndexVersion,
-		Nodes:   s.graph.Nodes,
-		Edges:   s.graph.Edges,
+		Nodes:   nodes,
+		Edges:   edges,
 	}
 
 	tmpFile, err := os.CreateTemp(filepath.Dir(s.indexPath), filepath.Base(s.indexPath)+".tmp-*")


### PR DESCRIPTION
## Summary

- Adds `sync.RWMutex` to the RPG `Graph` struct to prevent concurrent map access crashes
- The crash (`concurrent map iteration and map write`) occurred when the persist goroutine (GOB-encoding `graph.Nodes` every 1s) ran concurrently with the event handler goroutine (calling `RemoveNode`, which deletes from the same map)
- `RemoveEdgesIf` rewritten with snapshot+apply pattern to avoid re-entrant locking (the predicate calls `NodePath` which acquires a read lock; evaluating it while holding a write lock would deadlock)
- `persistUnlocked` snapshots Nodes/Edges under `RLock` before encoding, so graph mutations can proceed during the slow GOB encode
- `BuildFull` uses a new atomic `Reset()` method instead of direct field assignment

## Why only Qdrant triggered this

The race exists for all backends, but Qdrant makes it reliably triggerable:

- **GOB store**: `DeleteByFile` is an in-memory map delete (~microseconds). A burst of events finishes in <1ms — the 1s persist timer never fires during the mutation window.
- **Qdrant**: `DeleteByFile` is a network round-trip (~300–3800ms per event). A burst of 10 events spans multiple persist intervals, giving the timer many chances to fire mid-mutation.

The incremental indexing PR (#205) amplified this by making the initial scan complete in ~10s instead of minutes, pushing the watch loop into steady state much sooner.

## Test plan

- [x] `make test` passes with `-race` flag
- [x] `grepai watch` with Qdrant backend: trigger file changes during watch, confirm no `concurrent map iteration and map write` crash