### PR TITLE
fix(qdrant): increase gRPC max message size and drop unused vectors from GetAllChunks

### DIFF
--- a/store/qdrant.go
+++ b/store/qdrant.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/qdrant/go-client/qdrant"
+	"google.golang.org/grpc"
 )
 
 // sanitizeUTF8 ensures the string contains only valid UTF-8 characters.
@@ -54,6 +55,9 @@ func NewQdrantStore(ctx context.Context, endpoint string, port int, useTLS bool,
 		Port:   port,
 		UseTLS: useTLS,
 		APIKey: apiKey,
+		GrpcOptions: []grpc.DialOption{
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(64 * 1024 * 1024)),
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Qdrant client: %w", err)
@@ -475,7 +479,6 @@ func (s *QdrantStore) GetAllChunks(ctx context.Context) ([]Chunk, error) {
 		CollectionName: s.collectionName,
 		Limit:          qdrant.PtrOf(uint32(100000)),
 		WithPayload:    qdrant.NewWithPayloadInclude("file_path", "start_line", "end_line", "content", "hash", "updated_at"),
-		WithVectors:    qdrant.NewWithVectors(true),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all chunks: %w", err)


### PR DESCRIPTION
## Problem

On larger repositories, `grepai search` fails with:

```
error: failed to get all chunks: ScrollAndOffset() failed: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (6225529 vs. 4194304)
```

The gRPC default max receive message size is 4MB. `GetAllChunks` fetches chunks with full embedding vectors (`WithVectors: true`), causing Qdrant scroll responses to exceed that limit.

## Fix

Two changes in `store/qdrant.go`:

1. **Raise gRPC max receive message size to 64MB** via `GrpcOptions` on the Qdrant client config.

2. **Remove `WithVectors: true` from `GetAllChunks`** — the only caller is `hybridSearch` → `TextSearch`, which only reads `FilePath` and `Content`, never vectors. This matches the Postgres implementation which already omits vectors in its `GetAllChunks`. Removing vectors reduces response size by ~75%, making the 64MB limit viable for collections of 30,000+ chunks.

## Test plan

- [x] `go test ./store/` passes
- [ ] Manual: `grepai search "..." --json` succeeds on a large repository that previously triggered the error