### PR TITLE
feat(indexer): use per-file ModTime to skip unchanged files on watch restart

### DIFF
--- a/cli/watch.go
+++ b/cli/watch.go
@@ -815,12 +815,9 @@ func runInitialScan(ctx context.Context, idx *indexer.Indexer, scanner *indexer.
 			continue
 		}
 
-		// Skip files that are unchanged since the last index run and already tracked.
-		if !lastIndexTime.IsZero() {
-			fileModTime := time.Unix(file.ModTime, 0)
-			if (fileModTime.Before(lastIndexTime) || fileModTime.Equal(lastIndexTime)) && symbolStore.IsFileIndexed(file.Path) {
-				continue
-			}
+		// Skip files verified unchanged by the indexer (per-file ModTime or hash match).
+		if stats.UnchangedFiles[file.Path] && symbolStore.IsFileIndexed(file.Path) {
+			continue
 		}
 
 		fileInfo, err := scanner.ScanFile(file.Path)

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -22,12 +22,13 @@ type Indexer struct {
 }
 
 type IndexStats struct {
-	FilesIndexed  int
-	FilesSkipped  int
-	ChunksCreated int
-	FilesRemoved  int
-	Duration      time.Duration
-	ScannedFiles  []FileMeta // All files found during scan (for reuse by callers)
+	FilesIndexed   int
+	FilesSkipped   int
+	ChunksCreated  int
+	FilesRemoved   int
+	Duration       time.Duration
+	ScannedFiles   []FileMeta      // All files found during scan (for reuse by callers)
+	UnchangedFiles map[string]bool // Files verified unchanged (by ModTime or hash) for callers to reuse
 }
 
 // ProgressInfo contains progress information for indexing
@@ -93,7 +94,9 @@ func (idx *Indexer) IndexAllWithProgress(ctx context.Context, onProgress Progres
 // When the embedder implements BatchEmbedder, files are processed in parallel using cross-file batching.
 func (idx *Indexer) IndexAllWithBatchProgress(ctx context.Context, onProgress ProgressCallback, onBatchProgress BatchProgressCallback) (*IndexStats, error) {
 	start := time.Now()
-	stats := &IndexStats{}
+	stats := &IndexStats{
+		UnchangedFiles: make(map[string]bool),
+	}
 
 	// Scan all files (metadata-only first pass)
 	fileMetas, skipped, err := idx.scanner.ScanMetadata()
@@ -135,12 +138,25 @@ func (idx *Indexer) IndexAllWithBatchProgress(ctx context.Context, onProgress Pr
 		// Skip files modified before lastIndexTime — but only if they have chunks.
 		// Files with no chunks need re-indexing even if their mod_time is old
 		// (e.g., a prior indexing run created the document but failed to embed).
-		if !idx.lastIndexTime.IsZero() && doc != nil && len(doc.ChunkIDs) > 0 {
+		if doc != nil && len(doc.ChunkIDs) > 0 {
 			fileModTime := time.Unix(fileMeta.ModTime, 0)
-			if fileModTime.Before(idx.lastIndexTime) || fileModTime.Equal(idx.lastIndexTime) {
+
+			// Primary: per-file ModTime comparison — precise, no file I/O needed.
+			if !doc.ModTime.IsZero() && fileModTime.Equal(doc.ModTime) {
 				stats.FilesSkipped++
+				stats.UnchangedFiles[fileMeta.Path] = true
 				delete(existingMap, fileMeta.Path)
 				continue
+			}
+
+			// Fallback: global lastIndexTime for legacy documents without stored ModTime.
+			if !idx.lastIndexTime.IsZero() && doc.ModTime.IsZero() {
+				if fileModTime.Before(idx.lastIndexTime) || fileModTime.Equal(idx.lastIndexTime) {
+					stats.FilesSkipped++
+					stats.UnchangedFiles[fileMeta.Path] = true
+					delete(existingMap, fileMeta.Path)
+					continue
+				}
 			}
 		}
 
@@ -159,6 +175,16 @@ func (idx *Indexer) IndexAllWithBatchProgress(ctx context.Context, onProgress Pr
 		}
 
 		if doc != nil && doc.Hash == file.Hash && len(doc.ChunkIDs) > 0 {
+			// Content unchanged — update stored ModTime so future per-file checks
+			// can skip this file without reading its content (e.g. after git checkout).
+			newModTime := time.Unix(file.ModTime, 0)
+			if !newModTime.Equal(doc.ModTime) {
+				doc.ModTime = newModTime
+				if saveErr := idx.store.SaveDocument(ctx, *doc); saveErr != nil {
+					log.Printf("Warning: failed to update document mod_time for %s: %v", file.Path, saveErr)
+				}
+			}
+			stats.UnchangedFiles[file.Path] = true
 			delete(existingMap, fileMeta.Path)
 			continue // File unchanged and has chunks
 		}


### PR DESCRIPTION
Closes #216

## Summary

Replace the coarse global `lastIndexTime` check with precise **per-file ModTime comparison** when the watch command restarts. This eliminates unnecessary LLM embedding calls for unchanged files, dramatically reducing startup time on subsequent `grepai watch` runs.

## Problem

Every time `grepai watch` is restarted, it re-scans all files. The existing skip mechanism uses a single global `lastIndexTime` timestamp — any file whose ModTime is before this global cutoff gets skipped. This has two issues:

1. **Imprecise**: A file modified during a long initial scan (between its scan and when `lastIndexTime` is set at the end) could be silently skipped on the next restart
2. **Missed optimization**: The `Document` struct already stores per-file `ModTime`, but this value was never compared against the current file's ModTime for the skip decision

## Solution

**Primary check — per-file ModTime** (lines 144–150 in indexer.go):
- Compare each file's current ModTime against `doc.ModTime` stored in the index
- If they match and the document has chunks → skip immediately (no file I/O needed)

**Fallback — global `lastIndexTime`** (lines 153–159 in indexer.go):
- Preserved for backward compatibility with legacy index files where `doc.ModTime` is zero
- Only used when `doc.ModTime.IsZero()` (old documents created before this change)

**ModTime refresh on hash match** (lines 178–185 in indexer.go):
- When a file's content hash matches but ModTime differs (e.g., after `git checkout`), the stored ModTime is updated
- Future restarts benefit from the fast per-file ModTime path

**Symbol extraction optimization** (line 819 in watch.go):
- Uses the indexer's `UnchangedFiles` set instead of global timestamp comparison
- More accurate — skips only files the indexer actually verified as unchanged

## Backward Compatibility

- **GOB store**: `gob` decoding sets missing `time.Time` fields to zero value; the code gates on `!doc.ModTime.IsZero()` before using the per-file path → legacy files fall back to global `lastIndexTime`
- **Postgres**: `mod_time TIMESTAMP` column already exists; `ON CONFLICT DO UPDATE` handles the new writes
- **Qdrant**: `SaveDocument` is a no-op and `GetDocument` returns empty `ChunkIDs`, so the new per-file gate is never entered

## Test Results

- All 15 test packages pass with `-race` flag
- `go vet ./...` clean
- End-to-end verified with LM Studio (`text-embedding-nomic-embed-text-v1.5`):
  - First run: 3 files indexed (315ms)
  - Restart unchanged: **0 indexed, 3 skipped (0s — no LLM calls)**
  - 1 modified + 1 new: 2 indexed, 2 skipped (158ms)
  - 1 deleted: 1 removed, 3 skipped (0s)

## Checklist

- [x] Tests pass (`go test -race ./...`)
- [x] `go vet ./...` clean
- [x] Backward compatible with existing GOB/Postgres/Qdrant stores
- [x] No new dependencies
- [x] End-to-end tested with real LLM embedder

