### PR TITLE
fix(qdrant): persist document metadata locally to enable incremental

### DIFF
--- a/cli/search.go
+++ b/cli/search.go
@@ -252,7 +252,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 			collectionName = store.SanitizeCollectionName(projectRoot)
 		}
 		var err error
-		st, err = store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.GetDimensions())
+		st, err = store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.GetDimensions(), config.GetDocumentsPath(projectRoot))
 		if err != nil {
 			return fmt.Errorf("failed to connect to qdrant: %w", err)
 		}
@@ -586,7 +586,7 @@ func runWorkspaceSearch(ctx context.Context, query string, projects []string, pa
 		if collectionName == "" {
 			collectionName = "workspace_" + ws.Name
 		}
-		st, err = store.NewQdrantStore(ctx, ws.Store.Qdrant.Endpoint, ws.Store.Qdrant.Port, ws.Store.Qdrant.UseTLS, collectionName, ws.Store.Qdrant.APIKey, ws.Embedder.GetDimensions())
+		st, err = store.NewQdrantStore(ctx, ws.Store.Qdrant.Endpoint, ws.Store.Qdrant.Port, ws.Store.Qdrant.UseTLS, collectionName, ws.Store.Qdrant.APIKey, ws.Embedder.GetDimensions(), "")
 		if err != nil {
 			return fmt.Errorf("failed to connect to qdrant: %w", err)
 		}

--- a/cli/status.go
+++ b/cli/status.go
@@ -470,7 +470,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			collectionName = store.SanitizeCollectionName(projectRoot)
 		}
 		var err error
-		st, err = store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.GetDimensions())
+		st, err = store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.GetDimensions(), config.GetDocumentsPath(projectRoot))
 		if err != nil {
 			return fmt.Errorf("failed to connect to qdrant: %w", err)
 		}

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -460,7 +460,7 @@ func initializeStore(ctx context.Context, cfg *config.Config, projectRoot string
 		if collectionName == "" {
 			collectionName = store.SanitizeCollectionName(projectRoot)
 		}
-		return store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.GetDimensions())
+		return store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.GetDimensions(), config.GetDocumentsPath(projectRoot))
 	default:
 		return nil, fmt.Errorf("unknown storage backend: %s", cfg.Store.Backend)
 	}
@@ -2548,7 +2548,8 @@ func runWorkspaceWatchForeground(logDir string, ws *config.Workspace) error {
 	defer emb.Close()
 
 	// Initialize shared store with workspace-specific project ID
-	st, err := initializeWorkspaceStore(ctx, ws)
+	wsDocsPath := filepath.Join(logDir, "workspace_"+ws.Name+"_documents.gob")
+	st, err := initializeWorkspaceStore(ctx, ws, wsDocsPath)
 	if err != nil {
 		return fmt.Errorf("failed to initialize store: %w", err)
 	}
@@ -2864,7 +2865,7 @@ func initializeWorkspaceRuntime(ctx context.Context, ws *config.Workspace, proje
 	return runtime, w, nil
 }
 
-func initializeWorkspaceStore(ctx context.Context, ws *config.Workspace) (store.VectorStore, error) {
+func initializeWorkspaceStore(ctx context.Context, ws *config.Workspace, documentsPath string) (store.VectorStore, error) {
 	// Use workspace name as project ID for shared store
 	projectID := "workspace:" + ws.Name
 
@@ -2876,7 +2877,7 @@ func initializeWorkspaceStore(ctx context.Context, ws *config.Workspace) (store.
 		if collectionName == "" {
 			collectionName = "workspace_" + ws.Name
 		}
-		return store.NewQdrantStore(ctx, ws.Store.Qdrant.Endpoint, ws.Store.Qdrant.Port, ws.Store.Qdrant.UseTLS, collectionName, ws.Store.Qdrant.APIKey, ws.Embedder.GetDimensions())
+		return store.NewQdrantStore(ctx, ws.Store.Qdrant.Endpoint, ws.Store.Qdrant.Port, ws.Store.Qdrant.UseTLS, collectionName, ws.Store.Qdrant.APIKey, ws.Embedder.GetDimensions(), documentsPath)
 	default:
 		return nil, fmt.Errorf("unsupported backend for workspace: %s", ws.Store.Backend)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ const (
 	IndexFileName       = "index.gob"
 	SymbolIndexFileName = "symbols.gob"
 	RPGIndexFileName    = "rpg.gob"
+	DocumentsFileName   = "documents.gob"
 
 	DefaultEmbedderProvider         = "ollama"
 	DefaultOllamaEmbeddingModel     = "nomic-embed-text"
@@ -486,6 +487,10 @@ func GetSymbolIndexPath(projectRoot string) string {
 
 func GetRPGIndexPath(projectRoot string) string {
 	return filepath.Join(GetConfigDir(projectRoot), RPGIndexFileName)
+}
+
+func GetDocumentsPath(projectRoot string) string {
+	return filepath.Join(GetConfigDir(projectRoot), DocumentsFileName)
 }
 
 func Load(projectRoot string) (*Config, error) {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1010,7 +1010,7 @@ func (s *Server) createWorkspaceStore(ctx context.Context, ws *config.Workspace)
 		if collectionName == "" {
 			collectionName = "workspace_" + ws.Name
 		}
-		return store.NewQdrantStore(ctx, ws.Store.Qdrant.Endpoint, ws.Store.Qdrant.Port, ws.Store.Qdrant.UseTLS, collectionName, ws.Store.Qdrant.APIKey, ws.Embedder.GetDimensions())
+		return store.NewQdrantStore(ctx, ws.Store.Qdrant.Endpoint, ws.Store.Qdrant.Port, ws.Store.Qdrant.UseTLS, collectionName, ws.Store.Qdrant.APIKey, ws.Embedder.GetDimensions(), "")
 	default:
 		return nil, fmt.Errorf("unsupported backend for workspace: %s", ws.Store.Backend)
 	}
@@ -2052,7 +2052,7 @@ func (s *Server) createStore(ctx context.Context, cfg *config.Config) (store.Vec
 		if collectionName == "" {
 			collectionName = store.SanitizeCollectionName(s.projectRoot)
 		}
-		return store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.GetDimensions())
+		return store.NewQdrantStore(ctx, cfg.Store.Qdrant.Endpoint, cfg.Store.Qdrant.Port, cfg.Store.Qdrant.UseTLS, collectionName, cfg.Store.Qdrant.APIKey, cfg.Embedder.GetDimensions(), config.GetDocumentsPath(s.projectRoot))
 	default:
 		return nil, fmt.Errorf("unknown storage backend: %s", cfg.Store.Backend)
 	}

--- a/store/qdrant.go
+++ b/store/qdrant.go
@@ -2,13 +2,17 @@ package store
 
 import (
 	"context"
+	"encoding/gob"
 	"fmt"
+	"os"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/qdrant/go-client/qdrant"
+	"github.com/yoanbernabeu/grepai/internal/fileutil"
 )
 
 // sanitizeUTF8 ensures the string contains only valid UTF-8 characters.
@@ -25,6 +29,9 @@ type QdrantStore struct {
 	collectionName string
 	dimensions     int
 	apiKey         string
+	documents      map[string]Document
+	docPath        string
+	mu             sync.RWMutex
 }
 
 func parseHost(endpoint string) string {
@@ -42,7 +49,7 @@ func parseHost(endpoint string) string {
 	return host
 }
 
-func NewQdrantStore(ctx context.Context, endpoint string, port int, useTLS bool, collection, apiKey string, dimensions int) (*QdrantStore, error) {
+func NewQdrantStore(ctx context.Context, endpoint string, port int, useTLS bool, collection, apiKey string, dimensions int, documentsPath string) (*QdrantStore, error) {
 	host := parseHost(endpoint)
 
 	if port <= 0 {
@@ -64,10 +71,16 @@ func NewQdrantStore(ctx context.Context, endpoint string, port int, useTLS bool,
 		collectionName: collection,
 		dimensions:     dimensions,
 		apiKey:         apiKey,
+		documents:      make(map[string]Document),
+		docPath:        documentsPath,
 	}
 
 	if err := store.ensureCollection(ctx); err != nil {
 		return nil, err
+	}
+
+	if err := store.Load(ctx); err != nil {
+		return nil, fmt.Errorf("failed to load documents metadata: %w", err)
 	}
 
 	return store, nil
@@ -305,77 +318,109 @@ func (s *QdrantStore) parseChunkPayload(payload map[string]*qdrant.Value) *Chunk
 }
 
 func (s *QdrantStore) GetDocument(ctx context.Context, filePath string) (*Document, error) {
-	filter := &qdrant.Filter{
-		Must: []*qdrant.Condition{
-			qdrant.NewMatch("file_path", filePath),
-		},
-	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	scrollResult, err := s.client.Scroll(ctx, &qdrant.ScrollPoints{
-		CollectionName: s.collectionName,
-		Filter:         filter,
-		Limit:          qdrant.PtrOf(uint32(1)),
-		WithPayload:    qdrant.NewWithPayloadInclude("chunk_ids"),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get document: %w", err)
-	}
-
-	if len(scrollResult) == 0 {
+	doc, ok := s.documents[filePath]
+	if !ok {
 		return nil, nil
 	}
 
-	doc := &Document{
-		Path:     filePath,
-		ChunkIDs: []string{},
-	}
-
-	return doc, nil
+	return &doc, nil
 }
 
 func (s *QdrantStore) SaveDocument(ctx context.Context, doc Document) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.documents[doc.Path] = doc
 	return nil
 }
 
 func (s *QdrantStore) DeleteDocument(ctx context.Context, filePath string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.documents, filePath)
 	return nil
 }
 
 func (s *QdrantStore) ListDocuments(ctx context.Context) ([]string, error) {
-	scrollResult, err := s.client.Scroll(ctx, &qdrant.ScrollPoints{
-		CollectionName: s.collectionName,
-		Limit:          qdrant.PtrOf(uint32(1000)),
-		WithPayload:    qdrant.NewWithPayloadInclude("file_path"),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list documents: %w", err)
-	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	pathsMap := make(map[string]bool)
-	for _, point := range scrollResult {
-		if val, ok := point.Payload["file_path"]; ok {
-			pathsMap[val.GetStringValue()] = true
-		}
-	}
-
-	paths := make([]string, 0, len(pathsMap))
-	for path := range pathsMap {
+	paths := make([]string, 0, len(s.documents))
+	for path := range s.documents {
 		paths = append(paths, path)
 	}
 
 	return paths, nil
 }
 
+type qdrantDocData struct {
+	Documents map[string]Document
+}
+
 func (s *QdrantStore) Load(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.docPath == "" {
+		return nil
+	}
+
+	file, err := os.Open(s.docPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to open documents file: %w", err)
+	}
+	defer file.Close()
+
+	var data qdrantDocData
+	if err := gob.NewDecoder(file).Decode(&data); err != nil {
+		return fmt.Errorf("failed to decode documents: %w", err)
+	}
+
+	if data.Documents != nil {
+		s.documents = data.Documents
+	}
+
 	return nil
 }
 
 func (s *QdrantStore) Persist(ctx context.Context) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.docPath == "" {
+		return nil
+	}
+
+	if err := fileutil.EnsureParentDir(s.docPath); err != nil {
+		return fmt.Errorf("failed to prepare documents directory: %w", err)
+	}
+
+	file, err := os.Create(s.docPath)
+	if err != nil {
+		return fmt.Errorf("failed to create documents file: %w", err)
+	}
+	defer file.Close()
+
+	data := qdrantDocData{
+		Documents: s.documents,
+	}
+
+	if err := gob.NewEncoder(file).Encode(data); err != nil {
+		return fmt.Errorf("failed to encode documents: %w", err)
+	}
+
 	return nil
 }
 
 func (s *QdrantStore) Close() error {
-	return nil
+	return s.Persist(context.Background())
 }
 
 func (s *QdrantStore) GetStats(ctx context.Context) (*IndexStats, error) {

--- a/store/qdrant_test.go
+++ b/store/qdrant_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -391,6 +393,177 @@ func TestQdrantStore_DimensionsField(t *testing.T) {
 				t.Errorf("expected collectionName 'test', got %s", store.collectionName)
 			}
 		})
+	}
+}
+
+// TestQdrantStore_DocumentCRUD tests SaveDocument, GetDocument, DeleteDocument, and ListDocuments
+func TestQdrantStore_DocumentCRUD(t *testing.T) {
+	tmpDir := t.TempDir()
+	docPath := filepath.Join(tmpDir, "documents.gob")
+
+	store := &QdrantStore{
+		collectionName: "test",
+		dimensions:     768,
+		documents:      make(map[string]Document),
+		docPath:        docPath,
+	}
+
+	ctx := context.Background()
+
+	// GetDocument on empty store should return nil
+	doc, err := store.GetDocument(ctx, "test.go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc != nil {
+		t.Fatal("expected nil document")
+	}
+
+	// SaveDocument
+	now := time.Now()
+	err = store.SaveDocument(ctx, Document{
+		Path:     "test.go",
+		Hash:     "abc123",
+		ModTime:  now,
+		ChunkIDs: []string{"chunk1", "chunk2"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// GetDocument should return saved document
+	doc, err = store.GetDocument(ctx, "test.go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil document")
+	}
+	if doc.Hash != "abc123" {
+		t.Errorf("expected hash abc123, got %s", doc.Hash)
+	}
+	if len(doc.ChunkIDs) != 2 {
+		t.Errorf("expected 2 chunk IDs, got %d", len(doc.ChunkIDs))
+	}
+
+	// ListDocuments
+	paths, err := store.ListDocuments(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(paths) != 1 || paths[0] != "test.go" {
+		t.Errorf("expected [test.go], got %v", paths)
+	}
+
+	// DeleteDocument
+	err = store.DeleteDocument(ctx, "test.go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	doc, err = store.GetDocument(ctx, "test.go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc != nil {
+		t.Fatal("expected nil after delete")
+	}
+}
+
+// TestQdrantStore_LoadPersist tests document metadata persistence via GOB file
+func TestQdrantStore_LoadPersist(t *testing.T) {
+	tmpDir := t.TempDir()
+	docPath := filepath.Join(tmpDir, "documents.gob")
+
+	ctx := context.Background()
+
+	// Create store and save a document
+	store1 := &QdrantStore{
+		collectionName: "test",
+		dimensions:     768,
+		documents:      make(map[string]Document),
+		docPath:        docPath,
+	}
+
+	now := time.Now().Truncate(time.Second)
+	_ = store1.SaveDocument(ctx, Document{
+		Path:     "main.go",
+		Hash:     "hash123",
+		ModTime:  now,
+		ChunkIDs: []string{"c1", "c2", "c3"},
+	})
+
+	// Persist to disk
+	if err := store1.Persist(ctx); err != nil {
+		t.Fatalf("persist failed: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(docPath); os.IsNotExist(err) {
+		t.Fatal("documents.gob file was not created")
+	}
+
+	// Create a new store and load from disk
+	store2 := &QdrantStore{
+		collectionName: "test",
+		dimensions:     768,
+		documents:      make(map[string]Document),
+		docPath:        docPath,
+	}
+
+	if err := store2.Load(ctx); err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	// Verify document was loaded
+	doc, err := store2.GetDocument(ctx, "main.go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil document after load")
+	}
+	if doc.Hash != "hash123" {
+		t.Errorf("expected hash hash123, got %s", doc.Hash)
+	}
+	if len(doc.ChunkIDs) != 3 {
+		t.Errorf("expected 3 chunk IDs, got %d", len(doc.ChunkIDs))
+	}
+	if !doc.ModTime.Equal(now) {
+		t.Errorf("expected ModTime %v, got %v", now, doc.ModTime)
+	}
+}
+
+// TestQdrantStore_LoadNonExistentFile tests that Load handles missing file gracefully
+func TestQdrantStore_LoadNonExistentFile(t *testing.T) {
+	store := &QdrantStore{
+		collectionName: "test",
+		dimensions:     768,
+		documents:      make(map[string]Document),
+		docPath:        filepath.Join(t.TempDir(), "nonexistent.gob"),
+	}
+
+	// Load should succeed (no-op) when file doesn't exist
+	if err := store.Load(context.Background()); err != nil {
+		t.Fatalf("expected no error for nonexistent file, got %v", err)
+	}
+}
+
+// TestQdrantStore_EmptyDocPath tests that Load/Persist are no-ops when docPath is empty
+func TestQdrantStore_EmptyDocPath(t *testing.T) {
+	store := &QdrantStore{
+		collectionName: "test",
+		dimensions:     768,
+		documents:      make(map[string]Document),
+		docPath:        "",
+	}
+
+	ctx := context.Background()
+
+	if err := store.Load(ctx); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := store.Persist(ctx); err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
QdrantStore's SaveDocument/GetDocument/DeleteDocument were no-ops, causing the watch command to rescan the entire project on every run. Add a local GOB file (.grepai/documents.gob) to persist document metadata (hash, mod_time, chunk_ids) so the indexer can correctly skip unchanged files.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Fixes #

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Test Configuration:**
- OS:
- Go version:
- Embedding provider:

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's code style
- [ ] I have run `golangci-lint run` and fixed any issues
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed
- [ ] I have added an entry to CHANGELOG.md (if applicable)
- [ ] My changes generate no new warnings
- [ ] All new and existing tests pass

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
