### PR TITLE
fix(embedder): auto-split OpenAI batches exceeding 300k token limit (…

### DIFF
--- a/embedder/openai.go
+++ b/embedder/openai.go
@@ -351,7 +351,7 @@ func (e *OpenAIEmbedder) embedBatchWithRetry(
 			return nil, err
 		}
 
-		embeddings, err := e.embedBatchRequest(ctx, contents)
+		embeddings, err := e.embedTexts(ctx, contents)
 		if err == nil {
 			e.reportBatchSuccess(batch, totalBatches, totalChunks, completedChunks, estimatedTokens, progress)
 			return embeddings, nil
@@ -426,6 +426,13 @@ func handleEmbedErrorResponse(resp *http.Response, body []byte) error {
 		return NewContextLengthError(0, 0, 8191, msg)
 	}
 
+	// Check for batch-level token limit (request contains too many inputs in total)
+	if resp.StatusCode == http.StatusBadRequest && strings.Contains(msg, "maximum request size") {
+		retryErr := NewRetryableError(resp.StatusCode, fmt.Sprintf("OpenAI API error (status %d): %s", resp.StatusCode, msg))
+		retryErr.BatchTooLarge = true
+		return retryErr
+	}
+
 	retryErr := NewRetryableError(resp.StatusCode, fmt.Sprintf("OpenAI API error (status %d): %s", resp.StatusCode, msg))
 	if resp.StatusCode == http.StatusTooManyRequests {
 		headers := parseRateLimitHeaders(resp.Header)
@@ -452,6 +459,30 @@ func parseEmbeddingsResponse(body []byte, expectedCount int) ([][]float32, error
 	}
 
 	return embeddings, nil
+}
+
+// embedTexts embeds a slice of texts, automatically splitting the request in half
+// if the API returns a "maximum request size" error. This handles cases where our
+// token estimation undershoots the real count (e.g., dense or minified code).
+func (e *OpenAIEmbedder) embedTexts(ctx context.Context, texts []string) ([][]float32, error) {
+	embeddings, err := e.embedBatchRequest(ctx, texts)
+	if err == nil {
+		return embeddings, nil
+	}
+	retryErr, ok := err.(*RetryableError)
+	if ok && retryErr.BatchTooLarge && len(texts) > 1 {
+		mid := len(texts) / 2
+		left, err := e.embedTexts(ctx, texts[:mid])
+		if err != nil {
+			return nil, err
+		}
+		right, err := e.embedTexts(ctx, texts[mid:])
+		if err != nil {
+			return nil, err
+		}
+		return append(left, right...), nil
+	}
+	return nil, err
 }
 
 // embedBatchRequest makes a single embedding request to the OpenAI API.

--- a/embedder/retry.go
+++ b/embedder/retry.go
@@ -80,6 +80,7 @@ type RetryableError struct {
 	StatusCode       int
 	Message          string
 	Retryable        bool
+	BatchTooLarge    bool // true when the request exceeds the API's token-per-request limit
 	RateLimitHeaders *RateLimitHeaders
 }
 


### PR DESCRIPTION
…#214)

When token estimation undershoots (e.g. dense/minified code), the OpenAI API returns a 400 "maximum request size" error. Detect this as BatchTooLarge and recursively split the batch in half until each sub-batch succeeds.

## Description

    When token estimation undershoots (e.g. dense/minified code), the OpenAI
    API returns a 400 "maximum request size" error. Detect this as BatchTooLarge
    and recursively split the batch in half until each sub-batch succeeds.

## Related Issue

Fixes #214 

## Type of Change

- [ X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ X] Manual testing

**Test Configuration:**
- OS:
- Go version:
- Embedding provider:

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's code style
- [ ] I have run `golangci-lint run` and fixed any issues
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed
- [ ] I have added an entry to CHANGELOG.md (if applicable)
- [ ] My changes generate no new warnings
- [ ] All new and existing tests pass

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
