### PR TITLE
feat(cli): add migrate-model command for legacy index migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-Model Index Support**: New `store.multi_model` config option tags chunks with their embedding provider/model. When enabled, search returns only chunks matching the current model, enabling safe model switching without full re-indexing.
+- **Startup Validation**: Watch and search commands now validate that no untagged chunks exist when `multi_model` is enabled, with a clear error message directing users to run `migrate-model`.
+
 ## [0.35.0] - 2026-03-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Multi-Model Index Support**: New `store.multi_model` config option tags chunks with their embedding provider/model. When enabled, search returns only chunks matching the current model, enabling safe model switching without full re-indexing.
 - **Startup Validation**: Watch and search commands now validate that no untagged chunks exist when `multi_model` is enabled, with a clear error message directing users to run `migrate-model`.
+- **migrate-model Command**: New `grepai migrate-model <provider/model>` command stamps legacy untagged chunks with a model identifier. Metadata-only operation; no embedding API calls.
 
 ## [0.35.0] - 2026-03-16
 

--- a/cli/migrate_model.go
+++ b/cli/migrate_model.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/yoanbernabeu/grepai/config"
+	"github.com/yoanbernabeu/grepai/store"
+)
+
+var migrateModelCmd = &cobra.Command{
+	Use:   "migrate-model <provider/model>",
+	Short: "Stamp untagged chunks with an embedding model identifier",
+	Long: `Stamp all chunks that have an empty EmbedModel field with the given
+provider/model string. This is required when enabling multi_model on an
+existing index so that legacy chunks become searchable under the new
+filtering rules.
+
+No embedding API calls are made; this is a metadata-only operation.
+
+Example:
+  grepai migrate-model ollama/nomic-embed-text`,
+	Args: cobra.ExactArgs(1),
+	RunE: runMigrateModel,
+}
+
+func init() {
+	rootCmd.AddCommand(migrateModelCmd)
+}
+
+func runMigrateModel(cmd *cobra.Command, args []string) error {
+	modelTag := args[0]
+
+	// Validate model tag format
+	if !strings.Contains(modelTag, "/") {
+		return fmt.Errorf("model tag must be in provider/model format (e.g. ollama/nomic-embed-text), got %q", modelTag)
+	}
+
+	parts := strings.SplitN(modelTag, "/", 2)
+	if parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("model tag must have non-empty provider and model (e.g. ollama/nomic-embed-text), got %q", modelTag)
+	}
+
+	ctx := context.Background()
+
+	// Find project root
+	projectRoot, err := config.FindProjectRoot()
+	if err != nil {
+		return err
+	}
+
+	// Load configuration
+	cfg, err := config.Load(projectRoot)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	// Only GOB backend supported for now
+	if cfg.Store.Backend != "gob" {
+		return fmt.Errorf("migrate-model currently supports only the gob backend, got %q", cfg.Store.Backend)
+	}
+
+	// Load store
+	indexPath := config.GetIndexPath(projectRoot)
+	gobStore := store.NewGOBStore(indexPath)
+	if err := gobStore.Load(ctx); err != nil {
+		return fmt.Errorf("failed to load index: %w", err)
+	}
+
+	// Get all chunks
+	allChunks, err := gobStore.GetAllChunks(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get chunks: %w", err)
+	}
+
+	// Find chunks with empty EmbedModel and stamp them
+	var migrated int
+	var updated []store.Chunk
+	for _, chunk := range allChunks {
+		if chunk.EmbedModel == "" {
+			chunk.EmbedModel = modelTag
+			updated = append(updated, chunk)
+			migrated++
+		}
+	}
+
+	if migrated == 0 {
+		fmt.Println("No untagged chunks found. All chunks already have a model tag.")
+		return nil
+	}
+
+	// Save updated chunks
+	if err := gobStore.SaveChunks(ctx, updated); err != nil {
+		return fmt.Errorf("failed to save updated chunks: %w", err)
+	}
+
+	// Persist to disk
+	if err := gobStore.Persist(ctx); err != nil {
+		return fmt.Errorf("failed to persist index: %w", err)
+	}
+
+	fmt.Printf("Migrated %d chunks with model tag %q.\n", migrated, modelTag)
+	return nil
+}

--- a/cli/multi_model.go
+++ b/cli/multi_model.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/yoanbernabeu/grepai/store"
+)
+
+// countUntaggedChunks returns the number of chunks with an empty EmbedModel field.
+func countUntaggedChunks(ctx context.Context, st store.VectorStore) (int, error) {
+	allChunks, err := st.GetAllChunks(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	var count int
+	for _, c := range allChunks {
+		if c.EmbedModel == "" {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/cli/search.go
+++ b/cli/search.go
@@ -263,6 +263,9 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 	// Create searcher with boost config
 	searcher := search.NewSearcher(st, emb, cfg.Search)
+	if cfg.Store.MultiModel {
+		searcher.SetEmbedModelFilter(cfg.EmbedModelTag())
+	}
 
 	normalizedPath, err := search.NormalizeProjectPathPrefix(searchPath, projectRoot)
 	if err != nil {

--- a/cli/search.go
+++ b/cli/search.go
@@ -261,6 +261,15 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	}
 	defer st.Close()
 
+	// Validate multi_model: reject if untagged chunks exist
+	if cfg.Store.MultiModel {
+		if count, checkErr := countUntaggedChunks(ctx, st); checkErr != nil {
+			return fmt.Errorf("failed to check for untagged chunks: %w", checkErr)
+		} else if count > 0 {
+			return fmt.Errorf("multi_model is enabled but %d chunks have no model tag. Run 'grepai migrate-model <provider/model>' to tag them before proceeding", count)
+		}
+	}
+
 	// Create searcher with boost config
 	searcher := search.NewSearcher(st, emb, cfg.Search)
 	if cfg.Store.MultiModel {

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -995,6 +995,9 @@ func watchProjectWithEventObserver(ctx context.Context, projectRoot string, emb 
 
 	// Initialize indexer
 	idx := indexer.NewIndexer(projectRoot, st, emb, chunker, scanner, cfg.Watch.LastIndexTime, processorRegistry)
+	if cfg.Store.MultiModel {
+		idx.SetEmbedModelTag(cfg.EmbedModelTag())
+	}
 
 	// Initialize symbol store and extractor
 	symbolStore := trace.NewGOBSymbolStore(config.GetSymbolIndexPath(projectRoot))
@@ -2762,6 +2765,9 @@ func initializeWorkspaceRuntime(ctx context.Context, ws *config.Workspace, proje
 		projectPath:   project.Path,
 	}
 	idx := indexer.NewIndexer(project.Path, vectorStore, emb, chunker, scanner, projectCfg.Watch.LastIndexTime, processorRegistry)
+	if projectCfg.Store.MultiModel {
+		idx.SetEmbedModelTag(projectCfg.EmbedModelTag())
+	}
 	extractor := trace.NewRegexExtractor()
 	symbolStore := trace.NewGOBSymbolStore(config.GetSymbolIndexPath(project.Path))
 	if err := symbolStore.Load(ctx); err != nil {

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -980,6 +980,15 @@ func watchProjectWithEventObserver(ctx context.Context, projectRoot string, emb 
 	}
 	defer st.Close()
 
+	// Validate multi_model: reject startup if untagged chunks exist
+	if cfg.Store.MultiModel {
+		if count, checkErr := countUntaggedChunks(ctx, st); checkErr != nil {
+			log.Printf("Warning: could not check for untagged chunks: %v", checkErr)
+		} else if count > 0 {
+			return fmt.Errorf("multi_model is enabled but %d chunks have no model tag. Run 'grepai migrate-model <provider/model>' to tag them before proceeding", count)
+		}
+	}
+
 	// Initialize ignore matcher
 	ignoreMatcher, err := indexer.NewIgnoreMatcher(projectRoot, cfg.Ignore, cfg.ExternalGitignore)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -183,9 +183,10 @@ func DefaultEmbedderForProvider(provider string) EmbedderConfig {
 }
 
 type StoreConfig struct {
-	Backend  string         `yaml:"backend"` // gob | postgres | qdrant
-	Postgres PostgresConfig `yaml:"postgres,omitempty"`
-	Qdrant   QdrantConfig   `yaml:"qdrant,omitempty"`
+	Backend    string         `yaml:"backend"` // gob | postgres | qdrant
+	MultiModel bool          `yaml:"multi_model,omitempty"` // When true, tag chunks with provider/model and filter on search
+	Postgres   PostgresConfig `yaml:"postgres,omitempty"`
+	Qdrant     QdrantConfig   `yaml:"qdrant,omitempty"`
 }
 
 type PostgresConfig struct {
@@ -203,6 +204,15 @@ type QdrantConfig struct {
 type ChunkingConfig struct {
 	Size    int `yaml:"size"`
 	Overlap int `yaml:"overlap"`
+}
+
+// EmbedModelTag returns the "provider/model" string used to tag chunks.
+// Returns empty string if either provider or model is empty.
+func (c *Config) EmbedModelTag() string {
+	if c.Embedder.Provider == "" || c.Embedder.Model == "" {
+		return ""
+	}
+	return c.Embedder.Provider + "/" + c.Embedder.Model
 }
 
 func DefaultStoreForBackend(backend string) StoreConfig {

--- a/config/multi_model_test.go
+++ b/config/multi_model_test.go
@@ -1,0 +1,54 @@
+package config
+
+import "testing"
+
+func TestMultiModelDefaultsFalse(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Store.MultiModel {
+		t.Errorf("expected MultiModel to default to false, got true")
+	}
+}
+
+func TestEmbedModelTag_ReturnsProviderSlashModel(t *testing.T) {
+	cfg := &Config{
+		Embedder: EmbedderConfig{
+			Provider: "ollama",
+			Model:    "nomic-embed-text",
+		},
+	}
+
+	tag := cfg.EmbedModelTag()
+	expected := "ollama/nomic-embed-text"
+	if tag != expected {
+		t.Errorf("expected %q, got %q", expected, tag)
+	}
+}
+
+func TestEmbedModelTag_EmptyProviderReturnsEmpty(t *testing.T) {
+	cfg := &Config{
+		Embedder: EmbedderConfig{
+			Provider: "",
+			Model:    "nomic-embed-text",
+		},
+	}
+
+	tag := cfg.EmbedModelTag()
+	if tag != "" {
+		t.Errorf("expected empty tag when provider is empty, got %q", tag)
+	}
+}
+
+func TestEmbedModelTag_EmptyModelReturnsEmpty(t *testing.T) {
+	cfg := &Config{
+		Embedder: EmbedderConfig{
+			Provider: "ollama",
+			Model:    "",
+		},
+	}
+
+	tag := cfg.EmbedModelTag()
+	if tag != "" {
+		t.Errorf("expected empty tag when model is empty, got %q", tag)
+	}
+}

--- a/docs/src/content/docs/backends/embedders.md
+++ b/docs/src/content/docs/backends/embedders.md
@@ -5,6 +5,13 @@ description: Configure embedding providers for grepai
 
 Embedders convert text (code chunks) into vector representations that enable semantic search.
 
+:::tip[Model Tagging]
+If you plan to switch embedding models, enable `store.multi_model: true` in your config.
+This tags each chunk with its provider/model, so search only returns results from the
+current model. When enabling on an existing index, run `grepai migrate-model <provider/model>`
+first to tag legacy chunks.
+:::
+
 ## Available Embedders
 
 | Provider | Type | Pros | Cons |

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -35,6 +35,12 @@ store:
   # Backend: "gob" (file-based), "postgres" (PostgreSQL with pgvector), or "qdrant"
   backend: gob
 
+  # Multi-model support (default: false)
+  # When true, each chunk is tagged with the provider/model used to embed it.
+  # Search only returns chunks matching the current provider/model.
+  # Enables safe model switching without re-indexing the entire codebase.
+  multi_model: false
+
   # PostgreSQL settings (if using postgres backend)
   postgres:
     dsn: postgres://user:pass@localhost:5432/grepai

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -19,6 +19,7 @@ type Indexer struct {
 	scanner       *Scanner
 	processor     *framework.ProcessorRegistry
 	lastIndexTime time.Time
+	embedModelTag string // "provider/model" tag set on chunks when multi_model is enabled
 }
 
 type IndexStats struct {
@@ -77,6 +78,12 @@ func NewIndexer(
 		processor:     processor,
 		lastIndexTime: lastIndexTime,
 	}
+}
+
+// SetEmbedModelTag sets the provider/model tag to stamp on every chunk.
+// When empty (default), no tag is set, preserving backward compatibility.
+func (idx *Indexer) SetEmbedModelTag(tag string) {
+	idx.embedModelTag = tag
 }
 
 // IndexAll performs a full index of the project (no progress reporting)
@@ -270,7 +277,8 @@ func (idx *Indexer) prepareFileChunks(
 }
 
 // createStoreChunks creates store.Chunk objects from chunk info and embeddings.
-func createStoreChunks(chunkInfos []ChunkInfo, embeddings [][]float32, now time.Time) ([]store.Chunk, []string) {
+// When embedModelTag is non-empty, it is stamped on every chunk.
+func createStoreChunks(chunkInfos []ChunkInfo, embeddings [][]float32, now time.Time, embedModelTag string) ([]store.Chunk, []string) {
 	chunks := make([]store.Chunk, len(chunkInfos))
 	chunkIDs := make([]string, len(chunkInfos))
 
@@ -284,6 +292,7 @@ func createStoreChunks(chunkInfos []ChunkInfo, embeddings [][]float32, now time.
 			Vector:      embeddings[i],
 			Hash:        info.Hash,
 			ContentHash: info.ContentHash,
+			EmbedModel:  embedModelTag,
 			UpdatedAt:   now,
 		}
 		chunkIDs[i] = info.ID
@@ -408,7 +417,7 @@ func (idx *Indexer) indexFilesBatched(
 	for _, pf := range preFilledFiles {
 		fd := fileData[pf.fdIndex]
 		idx.remapChunksToSource(fd.chunkInfos, fd.file.Path, fd.source, fd.lineMap)
-		chunks, chunkIDs := createStoreChunks(fd.chunkInfos, pf.vectors, now)
+		chunks, chunkIDs := createStoreChunks(fd.chunkInfos, pf.vectors, now, idx.embedModelTag)
 		if err := idx.saveFileData(ctx, fd, chunks, chunkIDs); err != nil {
 			return filesIndexed, chunksCreated, err
 		}
@@ -434,7 +443,7 @@ func (idx *Indexer) indexFilesBatched(
 				continue
 			}
 			idx.remapChunksToSource(fd.chunkInfos, fd.file.Path, fd.source, fd.lineMap)
-			chunks, chunkIDs := createStoreChunks(fd.chunkInfos, embeddings, now)
+			chunks, chunkIDs := createStoreChunks(fd.chunkInfos, embeddings, now, idx.embedModelTag)
 			if err := idx.saveFileData(ctx, fd, chunks, chunkIDs); err != nil {
 				return filesIndexed, chunksCreated, err
 			}
@@ -552,6 +561,7 @@ func (idx *Indexer) IndexFile(ctx context.Context, file FileInfo) (int, error) {
 			Vector:      vectors[i],
 			Hash:        info.Hash,
 			ContentHash: info.ContentHash,
+			EmbedModel:  idx.embedModelTag,
 			UpdatedAt:   now,
 		}
 		chunkIDs[i] = info.ID

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -852,7 +852,7 @@ func TestCreateStoreChunks(t *testing.T) {
 			{0.4, 0.5, 0.6},
 		}
 
-		chunks, chunkIDs := createStoreChunks(chunkInfos, embeddings, now)
+		chunks, chunkIDs := createStoreChunks(chunkInfos, embeddings, now, "")
 
 		if len(chunks) != 2 {
 			t.Fatalf("expected 2 chunks, got %d", len(chunks))
@@ -891,7 +891,7 @@ func TestCreateStoreChunks(t *testing.T) {
 	})
 
 	t.Run("handles empty input", func(t *testing.T) {
-		chunks, chunkIDs := createStoreChunks([]ChunkInfo{}, [][]float32{}, now)
+		chunks, chunkIDs := createStoreChunks([]ChunkInfo{}, [][]float32{}, now, "")
 
 		if len(chunks) != 0 {
 			t.Errorf("expected 0 chunks, got %d", len(chunks))

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -492,6 +492,9 @@ func (s *Server) handleSearch(ctx context.Context, request mcp.CallToolRequest) 
 
 	// Create searcher and search
 	searcher := search.NewSearcher(st, emb, cfg.Search)
+	if cfg.Store.MultiModel {
+		searcher.SetEmbedModelFilter(cfg.EmbedModelTag())
+	}
 	normalizedPath, err := search.NormalizeProjectPathPrefix(path, s.projectRoot)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid path parameter: %v", err)), nil

--- a/search/search.go
+++ b/search/search.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Searcher struct {
-	store     store.VectorStore
-	embedder  embedder.Embedder
-	boostCfg  config.BoostConfig
-	hybridCfg config.HybridConfig
-	dedupCfg  config.DedupConfig
+	store         store.VectorStore
+	embedder      embedder.Embedder
+	boostCfg      config.BoostConfig
+	hybridCfg     config.HybridConfig
+	dedupCfg      config.DedupConfig
+	embedModelTag string // When non-empty, filter search results by this model tag
 }
 
 func NewSearcher(st store.VectorStore, emb embedder.Embedder, searchCfg config.SearchConfig) *Searcher {
@@ -24,6 +25,12 @@ func NewSearcher(st store.VectorStore, emb embedder.Embedder, searchCfg config.S
 		hybridCfg: searchCfg.Hybrid,
 		dedupCfg:  searchCfg.Dedup,
 	}
+}
+
+// SetEmbedModelFilter sets the model tag used to filter search results.
+// When non-empty, only chunks with this exact EmbedModel are returned.
+func (s *Searcher) SetEmbedModelFilter(tag string) {
+	s.embedModelTag = tag
 }
 
 func (s *Searcher) Search(ctx context.Context, query string, limit int, pathPrefix string) ([]store.SearchResult, error) {
@@ -40,10 +47,15 @@ func (s *Searcher) Search(ctx context.Context, query string, limit int, pathPref
 
 	var results []store.SearchResult
 
+	opts := store.SearchOptions{
+		PathPrefix: pathPrefix,
+		EmbedModel: s.embedModelTag,
+	}
+
 	if s.hybridCfg.Enabled {
-		results, err = s.hybridSearch(ctx, query, queryVector, fetchLimit, pathPrefix)
+		results, err = s.hybridSearch(ctx, query, queryVector, fetchLimit, opts)
 	} else {
-		results, err = s.store.Search(ctx, queryVector, fetchLimit, store.SearchOptions{PathPrefix: pathPrefix})
+		results, err = s.store.Search(ctx, queryVector, fetchLimit, opts)
 	}
 
 	if err != nil {
@@ -64,8 +76,8 @@ func (s *Searcher) Search(ctx context.Context, query string, limit int, pathPref
 }
 
 // hybridSearch combines vector search and text search using RRF.
-func (s *Searcher) hybridSearch(ctx context.Context, query string, queryVector []float32, limit int, pathPrefix string) ([]store.SearchResult, error) {
-	vectorResults, err := s.store.Search(ctx, queryVector, limit, store.SearchOptions{PathPrefix: pathPrefix})
+func (s *Searcher) hybridSearch(ctx context.Context, query string, queryVector []float32, limit int, opts store.SearchOptions) ([]store.SearchResult, error) {
+	vectorResults, err := s.store.Search(ctx, queryVector, limit, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +87,18 @@ func (s *Searcher) hybridSearch(ctx context.Context, query string, queryVector [
 		return nil, err
 	}
 
-	textResults := TextSearch(ctx, allChunks, query, limit, pathPrefix)
+	// Filter allChunks by embed model tag when set
+	if s.embedModelTag != "" {
+		filtered := make([]store.Chunk, 0, len(allChunks))
+		for _, c := range allChunks {
+			if c.EmbedModel == s.embedModelTag {
+				filtered = append(filtered, c)
+			}
+		}
+		allChunks = filtered
+	}
+
+	textResults := TextSearch(ctx, allChunks, query, limit, opts.PathPrefix)
 
 	k := s.hybridCfg.K
 	if k <= 0 {

--- a/store/embed_model_test.go
+++ b/store/embed_model_test.go
@@ -1,0 +1,185 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSearch_WithEmbedModelFilter_ReturnsOnlyMatching(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+
+	s := NewGOBStore(indexPath)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID:         "c1",
+			FilePath:   "a.go",
+			StartLine:  1,
+			EndLine:    10,
+			Content:    "func A() {}",
+			Vector:     []float32{1.0, 0.0, 0.0},
+			Hash:       "h1",
+			EmbedModel: "ollama/nomic-embed-text",
+			UpdatedAt:  time.Now(),
+		},
+		{
+			ID:         "c2",
+			FilePath:   "b.go",
+			StartLine:  1,
+			EndLine:    10,
+			Content:    "func B() {}",
+			Vector:     []float32{0.9, 0.1, 0.0},
+			Hash:       "h2",
+			EmbedModel: "openai/text-embedding-3-small",
+			UpdatedAt:  time.Now(),
+		},
+		{
+			ID:         "c3",
+			FilePath:   "c.go",
+			StartLine:  1,
+			EndLine:    10,
+			Content:    "func C() {}",
+			Vector:     []float32{0.8, 0.2, 0.0},
+			Hash:       "h3",
+			EmbedModel: "ollama/nomic-embed-text",
+			UpdatedAt:  time.Now(),
+		},
+	}
+
+	if err := s.SaveChunks(ctx, chunks); err != nil {
+		t.Fatalf("failed to save chunks: %v", err)
+	}
+
+	// Filter for ollama model only
+	results, err := s.Search(ctx, []float32{1.0, 0.0, 0.0}, 10, SearchOptions{
+		EmbedModel: "ollama/nomic-embed-text",
+	})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 results for ollama model, got %d", len(results))
+	}
+
+	for _, r := range results {
+		if r.Chunk.EmbedModel != "ollama/nomic-embed-text" {
+			t.Errorf("expected all results to have EmbedModel ollama/nomic-embed-text, got %q", r.Chunk.EmbedModel)
+		}
+	}
+}
+
+func TestSearch_WithEmbedModelFilter_ExcludesEmptyTag(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+
+	s := NewGOBStore(indexPath)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID:         "c1",
+			FilePath:   "a.go",
+			StartLine:  1,
+			EndLine:    10,
+			Content:    "func A() {}",
+			Vector:     []float32{1.0, 0.0, 0.0},
+			Hash:       "h1",
+			EmbedModel: "ollama/nomic-embed-text",
+			UpdatedAt:  time.Now(),
+		},
+		{
+			ID:        "c2",
+			FilePath:  "b.go",
+			StartLine: 1,
+			EndLine:   10,
+			Content:   "func B() {}",
+			Vector:    []float32{0.9, 0.1, 0.0},
+			Hash:      "h2",
+			// EmbedModel intentionally empty (legacy chunk)
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	if err := s.SaveChunks(ctx, chunks); err != nil {
+		t.Fatalf("failed to save chunks: %v", err)
+	}
+
+	// Filter for ollama model; empty-tagged chunks must be excluded
+	results, err := s.Search(ctx, []float32{1.0, 0.0, 0.0}, 10, SearchOptions{
+		EmbedModel: "ollama/nomic-embed-text",
+	})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("expected 1 result (empty tag excluded), got %d", len(results))
+	}
+
+	if len(results) > 0 && results[0].Chunk.ID != "c1" {
+		t.Errorf("expected c1, got %s", results[0].Chunk.ID)
+	}
+}
+
+func TestSearch_WithoutFilter_ReturnsAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+
+	s := NewGOBStore(indexPath)
+	ctx := context.Background()
+
+	chunks := []Chunk{
+		{
+			ID:         "c1",
+			FilePath:   "a.go",
+			StartLine:  1,
+			EndLine:    10,
+			Content:    "func A() {}",
+			Vector:     []float32{1.0, 0.0, 0.0},
+			Hash:       "h1",
+			EmbedModel: "ollama/nomic-embed-text",
+			UpdatedAt:  time.Now(),
+		},
+		{
+			ID:        "c2",
+			FilePath:  "b.go",
+			StartLine: 1,
+			EndLine:   10,
+			Content:   "func B() {}",
+			Vector:    []float32{0.9, 0.1, 0.0},
+			Hash:      "h2",
+			// Empty EmbedModel
+			UpdatedAt: time.Now(),
+		},
+		{
+			ID:         "c3",
+			FilePath:   "c.go",
+			StartLine:  1,
+			EndLine:    10,
+			Content:    "func C() {}",
+			Vector:     []float32{0.8, 0.2, 0.0},
+			Hash:       "h3",
+			EmbedModel: "openai/text-embedding-3-small",
+			UpdatedAt:  time.Now(),
+		},
+	}
+
+	if err := s.SaveChunks(ctx, chunks); err != nil {
+		t.Fatalf("failed to save chunks: %v", err)
+	}
+
+	// No EmbedModel filter: all chunks returned (default behavior)
+	results, err := s.Search(ctx, []float32{1.0, 0.0, 0.0}, 10, SearchOptions{})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Errorf("expected 3 results (no filter), got %d", len(results))
+	}
+}

--- a/store/gob.go
+++ b/store/gob.go
@@ -74,6 +74,10 @@ func (s *GOBStore) Search(ctx context.Context, queryVector []float32, limit int,
 		if opts.PathPrefix != "" && !strings.HasPrefix(chunk.FilePath, opts.PathPrefix) {
 			continue
 		}
+		// Filter by embed model if provided (strict: empty tags excluded)
+		if opts.EmbedModel != "" && chunk.EmbedModel != opts.EmbedModel {
+			continue
+		}
 		score := cosineSimilarity(queryVector, chunk.Vector)
 		results = append(results, SearchResult{
 			Chunk: chunk,

--- a/store/store.go
+++ b/store/store.go
@@ -15,6 +15,7 @@ type Chunk struct {
 	Vector      []float32 `json:"vector"`
 	Hash        string    `json:"hash"`
 	ContentHash string    `json:"content_hash"` // SHA256 of raw content (path-independent)
+	EmbedModel  string    `json:"embed_model,omitempty"` // "provider/model" tag for multi-model indexing
 	UpdatedAt   time.Time `json:"updated_at"`
 }
 
@@ -35,6 +36,7 @@ type SearchResult struct {
 // SearchOptions contains optional filters for vector search queries.
 type SearchOptions struct {
 	PathPrefix string
+	EmbedModel string // When non-empty, only chunks with this exact EmbedModel are returned (strict; empty tags excluded).
 }
 
 // IndexStats contains statistics about the index


### PR DESCRIPTION
## Summary

Adds `grepai migrate-model <provider/model>` — a metadata-only command that stamps all chunks with an empty `EmbedModel` field with the given provider/model tag.

**Depends on #200** (multi-model index support). **Design discussion: #233.**

## What it does

```
grepai migrate-model ollama/nomic-embed-text
# Migrated 14 382 chunks with model tag "ollama/nomic-embed-text".
```

- Validates `provider/model` format (must contain `/`, both parts non-empty)
- Currently supports the GOB backend only (returns a clear error for postgres/qdrant)
- No embedding API calls — pure metadata update
- Required workflow when enabling `store.multi_model: true` on an existing index so legacy chunks become searchable under the new per-model filtering

## Files changed

| File | Change |
|------|--------|
| `cli/migrate_model.go` | New command (106 lines) |
| `docs/src/content/docs/backends/embedders.md` | Model Tagging tip referencing this command |
| `CHANGELOG.md` | Unreleased entry |

## Related

Split from #199 (closed) as requested by maintainer. Part 3 of 3:
1. #231 — symlink/junction fix
2. #200 — multi-model index support (prerequisite)
3. This PR — migrate-model command

Design and open questions tracked in #233.