### PR TITLE
fix: scope Postgres embedding cache by project

### DIFF
--- a/store/postgres.go
+++ b/store/postgres.go
@@ -16,6 +16,8 @@ type PostgresStore struct {
 	dimensions int
 }
 
+const lookupByContentHashSQL = `SELECT vector FROM chunks WHERE project_id = $1 AND content_hash = $2 AND vector IS NOT NULL LIMIT 1`
+
 func NewPostgresStore(ctx context.Context, dsn string, projectID string, vectorDimensions int) (*PostgresStore, error) {
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
@@ -61,7 +63,7 @@ func (s *PostgresStore) ensureSchema(ctx context.Context) error {
 			PRIMARY KEY (project_id, path)
 		)`,
 		`ALTER TABLE chunks ADD COLUMN IF NOT EXISTS content_hash TEXT DEFAULT ''`,
-		`CREATE INDEX IF NOT EXISTS idx_chunks_content_hash ON chunks(content_hash) WHERE content_hash != ''`,
+		`CREATE INDEX IF NOT EXISTS idx_chunks_project_content_hash ON chunks(project_id, content_hash) WHERE content_hash != ''`,
 		buildEnsureVectorSQL(s.dimensions),
 		// Migrate chunks primary key from (id) to (project_id, id) so that
 		// worktrees sharing the same database get their own chunk rows instead
@@ -381,8 +383,8 @@ func (s *PostgresStore) LookupByContentHash(ctx context.Context, contentHash str
 
 	var vec pgvector.Vector
 	err := s.pool.QueryRow(ctx,
-		`SELECT vector FROM chunks WHERE content_hash = $1 AND vector IS NOT NULL LIMIT 1`,
-		contentHash,
+		lookupByContentHashSQL,
+		s.projectID, contentHash,
 	).Scan(&vec)
 
 	if err == pgx.ErrNoRows {

--- a/store/postgres_integration_test.go
+++ b/store/postgres_integration_test.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestPostgresStoreLookupByContentHashIsProjectScoped(t *testing.T) {
+	dsn := os.Getenv("GREPAI_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("GREPAI_POSTGRES_TEST_DSN is not set")
+	}
+
+	ctx := context.Background()
+	victim, err := NewPostgresStore(ctx, dsn, "proj_victim", 3)
+	if err != nil {
+		t.Fatalf("failed to create victim store: %v", err)
+	}
+	defer victim.Close()
+
+	attacker, err := NewPostgresStore(ctx, dsn, "proj_attacker", 3)
+	if err != nil {
+		t.Fatalf("failed to create attacker store: %v", err)
+	}
+	defer attacker.Close()
+
+	if _, err := victim.pool.Exec(ctx, `TRUNCATE TABLE chunks, documents`); err != nil {
+		t.Fatalf("failed to clean tables: %v", err)
+	}
+
+	contentHash := "sha256:shared-content"
+	victimVector := []float32{9.9, 8.8, 7.7}
+	if err := victim.SaveChunks(ctx, []Chunk{{
+		ID:          "README.md_0",
+		FilePath:    "README.md",
+		StartLine:   1,
+		EndLine:     1,
+		Content:     "File: README.md\n\nShared content",
+		Vector:      victimVector,
+		Hash:        "victim-row",
+		ContentHash: contentHash,
+		UpdatedAt:   time.Now().UTC(),
+	}}); err != nil {
+		t.Fatalf("failed to save victim chunk: %v", err)
+	}
+
+	if _, found, err := attacker.LookupByContentHash(ctx, contentHash); err != nil {
+		t.Fatalf("attacker lookup failed: %v", err)
+	} else if found {
+		t.Fatal("attacker project should not reuse victim project's cached vector")
+	}
+
+	got, found, err := victim.LookupByContentHash(ctx, contentHash)
+	if err != nil {
+		t.Fatalf("victim lookup failed: %v", err)
+	}
+	if !found {
+		t.Fatal("victim project should find its own cached vector")
+	}
+	if len(got) != len(victimVector) {
+		t.Fatalf("victim vector length mismatch: got %d, want %d", len(got), len(victimVector))
+	}
+	for i := range got {
+		if got[i] != victimVector[i] {
+			t.Fatalf("victim vector mismatch at %d: got %v, want %v", i, got, victimVector)
+		}
+	}
+}

--- a/store/postgres_sql_test.go
+++ b/store/postgres_sql_test.go
@@ -48,6 +48,25 @@ func TestBuildEnsureVectorSQL_ContainsExpectedFragments(t *testing.T) {
 	}
 }
 
+func TestLookupByContentHashSQLScopesByProject(t *testing.T) {
+	expected := []string{
+		"SELECT vector FROM chunks",
+		"project_id = $1",
+		"content_hash = $2",
+		"vector IS NOT NULL",
+	}
+
+	for _, frag := range expected {
+		if !strings.Contains(lookupByContentHashSQL, frag) {
+			t.Fatalf("expected lookup SQL to contain %q, got: %q", frag, lookupByContentHashSQL)
+		}
+	}
+
+	if strings.Contains(lookupByContentHashSQL, "WHERE content_hash = $1") {
+		t.Fatalf("lookup SQL must not use content_hash as the first and only scope: %q", lookupByContentHashSQL)
+	}
+}
+
 // strconvItoa converts an int to string without importing strconv.
 // This keeps the test dependency surface minimal.
 func strconvItoa(n int) string {


### PR DESCRIPTION
## Summary
- scope Postgres content-hash embedding cache lookups by `project_id`
- add a project-scoped content-hash index for the new lookup shape
- add SQL and optional Postgres integration regression tests

Fixes #249

## Tests
- `docker run --rm -v /home/dem0/.config/superpowers/worktrees/grepai/fix-postgres-contenthash-cache-249-clean:/repo -w /repo golang:1.24-bookworm go test -mod=mod ./store`
- `docker run --rm --network host -e GREPAI_POSTGRES_TEST_DSN=postgres://postgres:postgres@127.0.0.1:55442/postgres?sslmode=disable -v /home/dem0/.config/superpowers/worktrees/grepai/fix-postgres-contenthash-cache-249-clean:/repo -w /repo golang:1.24-bookworm go test -mod=mod -run TestPostgresStoreLookupByContentHashIsProjectScoped -v ./store`
- `docker run --rm -u $(id -u):$(id -g) -e GOCACHE=/tmp/gocache -e GOMODCACHE=/tmp/gomodcache -v /home/dem0/.config/superpowers/worktrees/grepai/fix-postgres-contenthash-cache-249-clean:/repo -w /repo golang:1.24-bookworm go test -mod=mod ./...`