### PR TITLE
feat(embedder): configurable request timeout and max retries

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,17 @@ type EmbedderConfig struct {
 	APIKey      string `yaml:"api_key,omitempty"`
 	Dimensions  *int   `yaml:"dimensions,omitempty"`
 	Parallelism int    `yaml:"parallelism"` // Number of parallel workers for batch embedding (default: 4)
+	// RequestTimeoutSeconds is the HTTP client timeout for a single embedding
+	// request. 0 (the default) preserves the historical 60-second value.
+	// Raise this when running against slow self-hosted endpoints
+	// (e.g., ollama-cuda on a shared GPU) where embedding a full batch can
+	// take longer than a minute.
+	RequestTimeoutSeconds int `yaml:"request_timeout_seconds,omitempty"`
+	// MaxRetries caps the number of retry attempts for transient embedding
+	// failures (HTTP 429 / 5xx). 0 (the default) preserves the historical
+	// value of 5. Only consumed by providers that implement retry today
+	// (openai); other providers ignore it.
+	MaxRetries int `yaml:"max_retries,omitempty"`
 }
 
 // GetDimensions returns the configured dimensions or a default value.

--- a/embedder/factory.go
+++ b/embedder/factory.go
@@ -2,14 +2,27 @@ package embedder
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/yoanbernabeu/grepai/config"
 )
+
+// requestTimeout returns the configured HTTP request timeout, or zero if the
+// config does not override the embedder's default. Zero signals callers to
+// skip the With…Timeout option entirely.
+func requestTimeout(cfg *config.Config) time.Duration {
+	if cfg.Embedder.RequestTimeoutSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(cfg.Embedder.RequestTimeoutSeconds) * time.Second
+}
 
 // NewFromConfig creates an Embedder based on the provided configuration.
 // This factory function centralizes provider initialization and eliminates
 // code duplication across CLI commands and MCP server.
 func NewFromConfig(cfg *config.Config) (Embedder, error) {
+	timeout := requestTimeout(cfg)
+
 	switch cfg.Embedder.Provider {
 	case "ollama":
 		opts := []OllamaOption{
@@ -18,6 +31,9 @@ func NewFromConfig(cfg *config.Config) (Embedder, error) {
 		}
 		if cfg.Embedder.Dimensions != nil {
 			opts = append(opts, WithOllamaDimensions(*cfg.Embedder.Dimensions))
+		}
+		if timeout > 0 {
+			opts = append(opts, WithOllamaTimeout(timeout))
 		}
 		return NewOllamaEmbedder(opts...), nil
 
@@ -31,6 +47,12 @@ func NewFromConfig(cfg *config.Config) (Embedder, error) {
 		if cfg.Embedder.Dimensions != nil {
 			opts = append(opts, WithOpenAIDimensions(*cfg.Embedder.Dimensions))
 		}
+		if timeout > 0 {
+			opts = append(opts, WithOpenAITimeout(timeout))
+		}
+		if cfg.Embedder.MaxRetries > 0 {
+			opts = append(opts, WithOpenAIMaxRetries(cfg.Embedder.MaxRetries))
+		}
 		return NewOpenAIEmbedder(opts...)
 
 	case "lmstudio":
@@ -40,6 +62,9 @@ func NewFromConfig(cfg *config.Config) (Embedder, error) {
 		}
 		if cfg.Embedder.Dimensions != nil {
 			opts = append(opts, WithLMStudioDimensions(*cfg.Embedder.Dimensions))
+		}
+		if timeout > 0 {
+			opts = append(opts, WithLMStudioTimeout(timeout))
 		}
 		return NewLMStudioEmbedder(opts...), nil
 
@@ -52,6 +77,9 @@ func NewFromConfig(cfg *config.Config) (Embedder, error) {
 		if cfg.Embedder.Dimensions != nil {
 			opts = append(opts, WithSyntheticDimensions(*cfg.Embedder.Dimensions))
 		}
+		if timeout > 0 {
+			opts = append(opts, WithSyntheticTimeout(timeout))
+		}
 		return NewSyntheticEmbedder(opts...)
 
 	case "openrouter":
@@ -62,6 +90,9 @@ func NewFromConfig(cfg *config.Config) (Embedder, error) {
 		}
 		if cfg.Embedder.Dimensions != nil {
 			opts = append(opts, WithOpenRouterDimensions(*cfg.Embedder.Dimensions))
+		}
+		if timeout > 0 {
+			opts = append(opts, WithOpenRouterTimeout(timeout))
 		}
 		return NewOpenRouterEmbedder(opts...)
 

--- a/embedder/factory_test.go
+++ b/embedder/factory_test.go
@@ -2,6 +2,7 @@ package embedder
 
 import (
 	"testing"
+	"time"
 
 	"github.com/yoanbernabeu/grepai/config"
 )
@@ -154,6 +155,64 @@ func TestNewFromConfig_WithDimensions(t *testing.T) {
 
 	if emb.Dimensions() != 1024 {
 		t.Errorf("expected dimensions 1024, got %d", emb.Dimensions())
+	}
+}
+
+func TestNewFromConfig_RequestTimeoutAndMaxRetries(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	cfg := &config.Config{
+		Embedder: config.EmbedderConfig{
+			Provider:              "openai",
+			Model:                 "text-embedding-3-small",
+			RequestTimeoutSeconds: 300,
+			MaxRetries:            9,
+		},
+	}
+
+	emb, err := NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create embedder: %v", err)
+	}
+	defer emb.Close()
+
+	oai, ok := emb.(*OpenAIEmbedder)
+	if !ok {
+		t.Fatalf("expected *OpenAIEmbedder, got %T", emb)
+	}
+	if got := oai.client.Timeout; got != 300*time.Second {
+		t.Errorf("expected HTTP client timeout 5m, got %v", got)
+	}
+	if got := oai.retryPolicy.MaxAttempts; got != 9 {
+		t.Errorf("expected MaxAttempts 9, got %d", got)
+	}
+}
+
+func TestNewFromConfig_TimeoutDefaultsPreserved(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	cfg := &config.Config{
+		Embedder: config.EmbedderConfig{
+			Provider: "openai",
+			Model:    "text-embedding-3-small",
+		},
+	}
+
+	emb, err := NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create embedder: %v", err)
+	}
+	defer emb.Close()
+
+	oai, ok := emb.(*OpenAIEmbedder)
+	if !ok {
+		t.Fatalf("expected *OpenAIEmbedder, got %T", emb)
+	}
+	if got := oai.client.Timeout; got != 60*time.Second {
+		t.Errorf("expected default 60s timeout to be preserved, got %v", got)
+	}
+	if got := oai.retryPolicy.MaxAttempts; got != 5 {
+		t.Errorf("expected default MaxAttempts 5 to be preserved, got %d", got)
 	}
 }
 

--- a/embedder/lmstudio.go
+++ b/embedder/lmstudio.go
@@ -62,6 +62,16 @@ func WithLMStudioDimensions(dimensions int) LMStudioOption {
 	}
 }
 
+// WithLMStudioTimeout overrides the HTTP client timeout for embedding requests.
+// Values <= 0 are ignored, preserving the default.
+func WithLMStudioTimeout(d time.Duration) LMStudioOption {
+	return func(e *LMStudioEmbedder) {
+		if d > 0 && e.client != nil {
+			e.client.Timeout = d
+		}
+	}
+}
+
 func NewLMStudioEmbedder(opts ...LMStudioOption) *LMStudioEmbedder {
 	e := &LMStudioEmbedder{
 		endpoint:   defaultLMStudioEndpoint,

--- a/embedder/ollama.go
+++ b/embedder/ollama.go
@@ -52,6 +52,16 @@ func WithOllamaDimensions(dimensions int) OllamaOption {
 	}
 }
 
+// WithOllamaTimeout overrides the HTTP client timeout for embedding requests.
+// Values <= 0 are ignored, preserving the default.
+func WithOllamaTimeout(d time.Duration) OllamaOption {
+	return func(e *OllamaEmbedder) {
+		if d > 0 && e.client != nil {
+			e.client.Timeout = d
+		}
+	}
+}
+
 func NewOllamaEmbedder(opts ...OllamaOption) *OllamaEmbedder {
 	e := &OllamaEmbedder{
 		endpoint:   defaultOllamaEndpoint,

--- a/embedder/openai.go
+++ b/embedder/openai.go
@@ -98,6 +98,26 @@ func WithOpenAIRetryPolicy(policy RetryPolicy) OpenAIOption {
 	}
 }
 
+// WithOpenAITimeout overrides the HTTP client timeout for embedding requests.
+// Values <= 0 are ignored, preserving the default.
+func WithOpenAITimeout(d time.Duration) OpenAIOption {
+	return func(e *OpenAIEmbedder) {
+		if d > 0 && e.client != nil {
+			e.client.Timeout = d
+		}
+	}
+}
+
+// WithOpenAIMaxRetries sets the maximum retry attempts on the embedder's
+// retry policy. Values <= 0 are ignored, preserving the default.
+func WithOpenAIMaxRetries(n int) OpenAIOption {
+	return func(e *OpenAIEmbedder) {
+		if n > 0 {
+			e.retryPolicy.MaxAttempts = n
+		}
+	}
+}
+
 // WithOpenAITPMLimit sets the tokens-per-minute limit for proactive rate limiting.
 // When set > 0, the embedder will pace requests to stay within this limit.
 // Default: 0 (disabled). OpenAI Tier 1 limit is 1,000,000 TPM for embeddings.

--- a/embedder/openrouter.go
+++ b/embedder/openrouter.go
@@ -80,6 +80,16 @@ func WithOpenRouterDimensions(dimensions int) OpenRouterOption {
 	}
 }
 
+// WithOpenRouterTimeout overrides the HTTP client timeout for embedding
+// requests. Values <= 0 are ignored, preserving the default.
+func WithOpenRouterTimeout(d time.Duration) OpenRouterOption {
+	return func(e *OpenRouterEmbedder) {
+		if d > 0 && e.client != nil {
+			e.client.Timeout = d
+		}
+	}
+}
+
 func NewOpenRouterEmbedder(opts ...OpenRouterOption) (*OpenRouterEmbedder, error) {
 	e := &OpenRouterEmbedder{
 		endpoint:   defaultOpenRouterEndpoint,

--- a/embedder/synthetic.go
+++ b/embedder/synthetic.go
@@ -77,6 +77,16 @@ func WithSyntheticDimensions(dimensions int) SyntheticOption {
 	}
 }
 
+// WithSyntheticTimeout overrides the HTTP client timeout for embedding
+// requests. Values <= 0 are ignored, preserving the default.
+func WithSyntheticTimeout(d time.Duration) SyntheticOption {
+	return func(e *SyntheticEmbedder) {
+		if d > 0 && e.client != nil {
+			e.client.Timeout = d
+		}
+	}
+}
+
 func NewSyntheticEmbedder(opts ...SyntheticOption) (*SyntheticEmbedder, error) {
 	e := &SyntheticEmbedder{
 		endpoint:   defaultSyntheticEndpoint + defaultSyntheticPath,


### PR DESCRIPTION
## Problem

The HTTP client timeout (60s) and retry max-attempts (5) used by the embedders are compiled-in constants. They're well-tuned for OpenAI's hosted API but break down against slow self-hosted endpoints — a shared \`ollama-cuda\` instance handling other inference jobs can easily take \> 60s to return a single batch's embeddings, especially under model warm-up or memory pressure.

Symptom I hit while building a large workspace through a self-hosted Ollama:

\`\`\`
Warning: failed to initialize runtime for emacs-source: initial indexing failed:
failed to embed batches: failed to send request to OpenAI:
Post \"https://ollama.hr-home.xyz/v1/embeddings\":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
\`\`\`

The watcher abandons the whole project on the first batch that exceeds 60s, even though the underlying queue is still making forward progress on the server side. Larger projects (in my case \~47k chunks across emacs-source) become un-indexable end-to-end.

## Solution

Two new optional fields on \`EmbedderConfig\`:

\`\`\`yaml
embedder:
  provider: openai
  request_timeout_seconds: 600   # default: 0 = preserve historical 60s
  max_retries: 8                 # default: 0 = preserve historical 5
\`\`\`

- \`request_timeout_seconds\` becomes the \`http.Client.Timeout\` for the chosen embedder. Each of the five embedders (openai / ollama / lmstudio / openrouter / synthetic) gets a \`With…Timeout\` option; the factory threads the value through. Synthetic's existing 90s default is preserved when the field is unset.
- \`max_retries\` is honored by providers that already implement retry today — only \`openai\` does, so the field's docstring calls this out. Other providers silently ignore it (no behavior change). For openai, the value caps \`RetryPolicy.MaxAttempts\`.

Both fields are zero-valued by default and \*explicitly preserve existing behavior\* in that case. A bare \`embedder:\` block produces the same embedder as before this PR.

## Test plan

Two new tests in \`embedder/factory_test.go\`:

| Test | Asserts |
|---|---|
| \`TestNewFromConfig_RequestTimeoutAndMaxRetries\` | \`request_timeout_seconds: 300\` results in 5-minute \`client.Timeout\`; \`max_retries: 9\` results in \`retryPolicy.MaxAttempts == 9\` |
| \`TestNewFromConfig_TimeoutDefaultsPreserved\` | with both fields unset, defaults stay at 60s / 5 attempts |

All existing tests continue to pass (\`go test ./...\`).