### PR TITLE
feat(scanner): index projects rooted at a symlink

### DIFF
--- a/indexer/scanner.go
+++ b/indexer/scanner.go
@@ -117,6 +117,20 @@ type Scanner struct {
 }
 
 func NewScanner(root string, ignore *IgnoreMatcher) *Scanner {
+	// Resolve the project root if (and only if) it is itself a symlink to a
+	// directory. filepath.WalkDir does not descend into symlinked dirs, so a
+	// project rooted at a symlink would otherwise enumerate zero files. We
+	// only resolve the root entry — intermediate symlinks deeper in the tree
+	// remain skipped, which avoids recursion loops and surprising blow-ups
+	// when packages vendor third-party trees through symlinks. We deliberately
+	// do not call filepath.EvalSymlinks unconditionally because that would
+	// also rewrite parent-directory symlinks (e.g. /usr/local on a Nix system)
+	// and shift the project's stored path in ways the user didn't ask for.
+	if info, err := os.Lstat(root); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			root = resolved
+		}
+	}
 	return &Scanner{
 		root:   root,
 		ignore: ignore,

--- a/indexer/scanner_test.go
+++ b/indexer/scanner_test.go
@@ -352,3 +352,79 @@ func TestScanner_ScanFile_SkipsMinified(t *testing.T) {
 		t.Error("expected nil for minified file, got file info")
 	}
 }
+
+func TestScanner_SymlinkProjectRoot(t *testing.T) {
+	// Real directory containing source files.
+	realDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(realDir, "main.go"), []byte("package main"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(realDir, "sub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "sub", "nested.go"), []byte("package sub"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A symlink in a different parent pointing at the real directory.
+	linkParent := t.TempDir()
+	linkRoot := filepath.Join(linkParent, "via-symlink")
+	if err := os.Symlink(realDir, linkRoot); err != nil {
+		t.Skipf("cannot create symlinks in this environment: %v", err)
+	}
+
+	ignoreMatcher, err := NewIgnoreMatcher(linkRoot, []string{}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scanner := NewScanner(linkRoot, ignoreMatcher)
+	files, _, err := scanner.Scan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files via symlinked root, got %d: %+v", len(files), files)
+	}
+	// File paths must be relative to the resolved real root, not the
+	// symlink — otherwise downstream callers can't match them against
+	// re-scans or watcher events that arrive with resolved paths.
+	for _, f := range files {
+		if filepath.IsAbs(f.Path) {
+			t.Errorf("expected relative path, got absolute: %q", f.Path)
+		}
+	}
+}
+
+func TestScanner_RealDirRoot_NotEvalSymlinks(t *testing.T) {
+	// When the root is a real directory (not a symlink), the scanner must
+	// NOT call EvalSymlinks — we don't want parent symlinks (e.g. /usr/local
+	// on Nix systems) to silently rewrite the project's stored path.
+	parent := t.TempDir()
+	realRoot := filepath.Join(parent, "real")
+	if err := os.MkdirAll(realRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink to the parent of realRoot — i.e. realRoot/.. is reachable
+	// via a different absolute path.
+	linkParent := filepath.Join(t.TempDir(), "linked-parent")
+	if err := os.Symlink(parent, linkParent); err != nil {
+		t.Skipf("cannot create symlinks: %v", err)
+	}
+	rootViaLinkedParent := filepath.Join(linkParent, "real")
+
+	if err := os.WriteFile(filepath.Join(realRoot, "a.go"), []byte("package x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ignoreMatcher, err := NewIgnoreMatcher(rootViaLinkedParent, []string{}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanner := NewScanner(rootViaLinkedParent, ignoreMatcher)
+
+	if scanner.root != rootViaLinkedParent {
+		t.Errorf("scanner.root should stay as the caller-provided path (%q), got %q",
+			rootViaLinkedParent, scanner.root)
+	}
+}


### PR DESCRIPTION
## Problem

\`filepath.WalkDir\` does not descend into symlinked directories, so when a user points grepai at a project root that is itself a symlink, the scan silently enumerates zero files. There's no warning — just no results.

This is hostile to a common pattern: fronting a version-managed path with a stable name so the workspace survives upstream version bumps. For example:

\`\`\`
~/.emacs.d/emacs-sources -> /usr/share/emacs/30.2/
\`\`\`

A user puts \`emacs-sources\` in their workspace config so they don't have to retarget on every emacs upgrade. Today, that workspace indexes nothing.

## Solution

\`NewScanner\` now \`os.Lstat\`s the root and, only if it is a symlink to a directory, resolves it once via \`filepath.EvalSymlinks\` before \`WalkDir\` runs. Intermediate symlinks deeper in the tree are still skipped — that matches upstream's existing behavior and avoids recursion loops or surprising blow-ups when packages vendor third-party trees via symlinks.

We deliberately do **not** call \`EvalSymlinks\` on a real directory: doing so would also rewrite parent-directory symlinks (e.g. \`/usr/local\` on a Nix system) and silently shift the project's stored path in ways the caller never asked for. The \`os.Lstat\` guard makes the resolution opt-in based on the root entry's own type.

## Test plan

Two new tests in \`indexer/scanner_test.go\`:

| Test | Asserts |
|---|---|
| \`TestScanner_SymlinkProjectRoot\` | a symlink-to-directory root enumerates the underlying files; relative paths returned are relative to the resolved real root (not the symlink path) |
| \`TestScanner_RealDirRoot_NotEvalSymlinks\` | when the root is a real directory (even if its parent is reached through a symlink), \`scanner.root\` stays as the caller-provided path, no silent rewrite |

Both tests \`t.Skipf\` cleanly on environments that cannot create symlinks. All existing tests continue to pass (\`go test ./...\`).