### PR TITLE
feat(workspace): relocate per-project local state to ~/.grepai/

### DIFF
--- a/cli/watch.go
+++ b/cli/watch.go
@@ -2763,7 +2763,15 @@ func initializeWorkspaceRuntime(ctx context.Context, ws *config.Workspace, proje
 	}
 	idx := indexer.NewIndexer(project.Path, vectorStore, emb, chunker, scanner, projectCfg.Watch.LastIndexTime, processorRegistry)
 	extractor := trace.NewRegexExtractor()
-	symbolStore := trace.NewGOBSymbolStore(config.GetSymbolIndexPath(project.Path))
+	// Workspace projects keep their local state (symbol index, RPG index)
+	// under the workspace-scoped state dir rather than inside the project
+	// root. This lets us index read-only trees like /usr/share/emacs/30.2/
+	// without needing write access to the project root.
+	projectStateDir := ws.ProjectStateDir(project.Name)
+	if err := os.MkdirAll(projectStateDir, 0755); err != nil {
+		log.Printf("Warning: failed to create state dir %s for %s: %v", projectStateDir, project.Name, err)
+	}
+	symbolStore := trace.NewGOBSymbolStore(filepath.Join(projectStateDir, config.SymbolIndexFileName))
 	if err := symbolStore.Load(ctx); err != nil {
 		log.Printf("Warning: failed to load symbol index for %s: %v", project.Path, err)
 	}
@@ -2789,7 +2797,7 @@ func initializeWorkspaceRuntime(ctx context.Context, ws *config.Workspace, proje
 	var rpgEncoder *rpg.RPGEncoder
 	var manager *rpgRealtimeManager
 	if projectCfg.RPG.Enabled {
-		rpgStore = rpg.NewGOBRPGStore(config.GetRPGIndexPath(project.Path))
+		rpgStore = rpg.NewGOBRPGStore(filepath.Join(projectStateDir, config.RPGIndexFileName))
 		if err := rpgStore.Load(ctx); err != nil {
 			log.Printf("Warning: failed to load RPG index for %s: %v", project.Path, err)
 		}

--- a/config/workspace.go
+++ b/config/workspace.go
@@ -25,7 +25,43 @@ type Workspace struct {
 	Name     string         `yaml:"name"`
 	Store    StoreConfig    `yaml:"store"`
 	Embedder EmbedderConfig `yaml:"embedder"`
-	Projects []ProjectEntry `yaml:"projects"`
+	// LocalStateDir relocates each project's per-project local state
+	// (symbol index, RPG index, …) from `<projectRoot>/.grepai/` to a
+	// path under this directory. Use when a project root is read-only
+	// (e.g., /usr/share/emacs/<X.Y>/) so grepai cannot mkdir .grepai/
+	// inside it. A leading "~/" expands to the user's home. If empty,
+	// the default location is ~/.grepai/workspaces/<workspace-name>/.
+	LocalStateDir string         `yaml:"local_state_dir,omitempty"`
+	Projects      []ProjectEntry `yaml:"projects"`
+}
+
+// ResolvedLocalStateDir returns the workspace-level local state base
+// directory after expanding "~/" prefixes and applying defaults.
+func (ws *Workspace) ResolvedLocalStateDir() string {
+	base := ws.LocalStateDir
+	if base == "" {
+		// Default: ~/.grepai/workspaces/<workspace>/
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, ConfigDir, "workspaces", ws.Name)
+		}
+		return filepath.Join(ConfigDir, "workspaces", ws.Name)
+	}
+	if strings.HasPrefix(base, "~/") || base == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			if base == "~" {
+				return home
+			}
+			return filepath.Join(home, base[2:])
+		}
+	}
+	return base
+}
+
+// ProjectStateDir returns the per-project local-state directory under the
+// workspace's resolved LocalStateDir. The caller is responsible for
+// MkdirAll-ing the result before writing to it.
+func (ws *Workspace) ProjectStateDir(projectName string) string {
+	return filepath.Join(ws.ResolvedLocalStateDir(), projectName)
 }
 
 // ProjectEntry represents a single project within a workspace.

--- a/config/workspace_test.go
+++ b/config/workspace_test.go
@@ -516,3 +516,47 @@ func TestGetWorkspaceConfigPath(t *testing.T) {
 		t.Errorf("expected %s, got %s", expected, path)
 	}
 }
+
+func TestWorkspace_ResolvedLocalStateDir_Default(t *testing.T) {
+	tmpHome := t.TempDir()
+	defer setTestHomeDir(t, tmpHome)()
+
+	ws := &Workspace{Name: "emacs"}
+	got := ws.ResolvedLocalStateDir()
+	want := filepath.Join(tmpHome, ConfigDir, "workspaces", "emacs")
+	if got != want {
+		t.Errorf("default LocalStateDir: got %q, want %q", got, want)
+	}
+}
+
+func TestWorkspace_ResolvedLocalStateDir_TildeExpansion(t *testing.T) {
+	tmpHome := t.TempDir()
+	defer setTestHomeDir(t, tmpHome)()
+
+	ws := &Workspace{Name: "emacs", LocalStateDir: "~/grepai-state/emacs"}
+	got := ws.ResolvedLocalStateDir()
+	want := filepath.Join(tmpHome, "grepai-state", "emacs")
+	if got != want {
+		t.Errorf("tilde expansion: got %q, want %q", got, want)
+	}
+}
+
+func TestWorkspace_ResolvedLocalStateDir_AbsolutePassthrough(t *testing.T) {
+	ws := &Workspace{Name: "emacs", LocalStateDir: "/var/lib/grepai/emacs"}
+	got := ws.ResolvedLocalStateDir()
+	if got != "/var/lib/grepai/emacs" {
+		t.Errorf("absolute path should pass through, got %q", got)
+	}
+}
+
+func TestWorkspace_ProjectStateDir(t *testing.T) {
+	tmpHome := t.TempDir()
+	defer setTestHomeDir(t, tmpHome)()
+
+	ws := &Workspace{Name: "emacs"}
+	got := ws.ProjectStateDir("emacs-source")
+	want := filepath.Join(tmpHome, ConfigDir, "workspaces", "emacs", "emacs-source")
+	if got != want {
+		t.Errorf("project state dir: got %q, want %q", got, want)
+	}
+}

--- a/docs/src/content/docs/workspace.md
+++ b/docs/src/content/docs/workspace.md
@@ -278,6 +278,7 @@ When indexing via workspace, settings come from different sources:
 | `store` (backend, DSN) | **Workspace** | Shared store required |
 | `embedder` (provider, model) | **Workspace** | Ensures compatible vectors |
 | `chunking` (size, overlap) | **Project** | Can vary per project/language |
+| `local_state_dir` | **Workspace** | Where to keep per-project symbol/RPG indexes; defaults to `~/.grepai/workspaces/<name>/`. Override for read-only project roots. |
 | `ignore` patterns | **Project** | Project-specific exclusions |
 | `external_gitignore` | **Project** | Project-specific gitignore |
 


### PR DESCRIPTION
## Problem

When a workspace indexes a read-only project root — typical examples are \`/usr/share/emacs/<X.Y>/\`, \`/opt/foo/\`, or any directory owned by root and read-only for the user — grepai's attempt to \`mkdir <project_root>/.grepai/\` fails with \`EACCES\`. The symbol index and RPG index silently fail to persist; the watcher logs a warning per project on every run.

In my own workspace this affected \`emacs-source\` (\`/usr/share/emacs/30.2\`) and \`site-lisp\` (\`/usr/share/emacs/site-lisp\`). The PostgreSQL vector store still landed chunks fine, but the per-project local state was unreachable.

## Solution

Adds a workspace-level \`local_state_dir\` option:

\`\`\`yaml
workspaces:
  emacs:
    local_state_dir: ~/grepai-state   # or any absolute path
    projects:
      - name: emacs-source
        path: /usr/share/emacs/30.2
\`\`\`

- When set: each project's local state lives at \`<local_state_dir>/<project-name>/\`. A leading \`~/\` is expanded against the user's home.
- When **unset** (the new default): local state lives under \`~/.grepai/workspaces/<workspace-name>/<project-name>/\`. Workspace projects no longer touch the project root at all.

Two helpers — \`Workspace.ResolvedLocalStateDir()\` and \`Workspace.ProjectStateDir(projectName)\` — encapsulate the expansion + join logic and are useful for downstream consumers (e.g. future MCP tooling that wants to read the symbol index).

The workspace runner in \`cli/watch.go\` \`MkdirAll\`s the project state dir and feeds it to the GOB symbol + RPG stores instead of \`config.GetSymbolIndexPath(project.Path)\` / \`config.GetRPGIndexPath(project.Path)\`. Those helpers are unchanged and still target \`<project_root>/.grepai/\` for the single-project flow where it makes sense.

Single-project mode (\`grepai watch\` without \`--workspace\`) and per-project \`.grepai/config.yaml\` are unaffected — only the workspace runner changes location.

## Behavior change

Before: workspace projects created (or attempted to create) \`<project_root>/.grepai/\`.
After: workspace projects use \`~/.grepai/workspaces/<workspace-name>/<project-name>/\` by default.

Existing workspace users will see their per-project state move to a new location on first run after upgrade. Vector stores are unaffected (those go to PostgreSQL/Qdrant); only the GOB symbol/RPG indexes relocate. Each will rebuild on the next \`grepai watch --workspace …\`.

If preserving in-place behavior is preferred, the field can default to empty-with-fallback-to-project-root instead; happy to adjust based on review.

## Test plan

Four new tests in \`config/workspace_test.go\`:

| Test | Asserts |
|---|---|
| \`TestWorkspace_ResolvedLocalStateDir_Default\` | unset → \`~/.grepai/workspaces/<name>/\` |
| \`TestWorkspace_ResolvedLocalStateDir_TildeExpansion\` | \`~/foo\` expands to \`\$HOME/foo\` |
| \`TestWorkspace_ResolvedLocalStateDir_AbsolutePassthrough\` | \`/var/lib/...\` passes through verbatim |
| \`TestWorkspace_ProjectStateDir\` | composes resolved base with project name |

All existing tests continue to pass (\`go test ./...\`).