### PR TITLE
fix(workspace): scope projectPrefixStore.ListDocuments to this project

### DIFF
--- a/cli/watch.go
+++ b/cli/watch.go
@@ -2948,8 +2948,31 @@ func (p *projectPrefixStore) DeleteDocument(ctx context.Context, filePath string
 	return p.store.DeleteDocument(ctx, prefixedPath)
 }
 
+// ListDocuments returns only the documents whose path begins with this
+// project's workspace+project prefix, with the prefix stripped so the
+// indexer sees relative paths that match what its scanner enumerates.
+//
+// Without this filter the inner shared store returns every document in
+// the entire workspace; the indexer then treats every other project's
+// docs as "no longer present" and runs RemoveFile against each one. The
+// removes silently no-op (projectPrefixStore.DeleteByFile re-adds the
+// prefix, producing a doubly-prefixed path that never matches a stored
+// row), but the spurious work shows up as wildly inflated "files
+// removed" counts (the workspace total, on every per-project scan) and
+// thousands of pointless Postgres roundtrips on every restart.
 func (p *projectPrefixStore) ListDocuments(ctx context.Context) ([]string, error) {
-	return p.store.ListDocuments(ctx)
+	all, err := p.store.ListDocuments(ctx)
+	if err != nil {
+		return nil, err
+	}
+	prefix := p.getPrefix() + "/"
+	out := make([]string, 0, len(all))
+	for _, path := range all {
+		if strings.HasPrefix(path, prefix) {
+			out = append(out, strings.TrimPrefix(path, prefix))
+		}
+	}
+	return out, nil
 }
 
 func (p *projectPrefixStore) Load(ctx context.Context) error {

--- a/cli/watch_prefix_store_test.go
+++ b/cli/watch_prefix_store_test.go
@@ -217,8 +217,18 @@ func TestProjectPrefixStore_PassThroughAndGetChunks(t *testing.T) {
 	ctx := context.Background()
 	projectRoot := t.TempDir()
 	mock := &mockVectorStore{
-		searchResults:         []store.SearchResult{{Score: 0.9}},
-		listDocumentsResult:   []string{"a", "b"},
+		searchResults: []store.SearchResult{{Score: 0.9}},
+		// The underlying shared store sees the full workspace. ListDocuments
+		// must filter to this project's prefix and strip it before returning,
+		// so the indexer's scan-vs-stored diff doesn't treat other projects'
+		// documents as "removed".
+		listDocumentsResult: []string{
+			"ws/proj/main.go",
+			"ws/proj/sub/file.go",
+			"ws/other/main.go",          // different project — must be filtered out
+			"different-ws/proj/main.go", // different workspace — must be filtered out
+			"unprefixed.go",             // no workspace prefix — must be filtered out
+		},
 		getStatsResult:        &store.IndexStats{TotalFiles: 2},
 		listFilesResult:       []store.FileStats{{Path: "p"}},
 		getChunksForFileItems: []store.Chunk{{ID: "c1"}},
@@ -240,8 +250,18 @@ func TestProjectPrefixStore_PassThroughAndGetChunks(t *testing.T) {
 	}
 
 	docs, err := wrapped.ListDocuments(ctx)
-	if err != nil || len(docs) != 2 {
-		t.Fatalf("ListDocuments failed: %v %v", docs, err)
+	if err != nil {
+		t.Fatalf("ListDocuments failed: %v", err)
+	}
+	wantDocs := []string{"main.go", "sub/file.go"}
+	if len(docs) != len(wantDocs) {
+		t.Fatalf("ListDocuments: expected %d paths (filtered + stripped), got %d: %v",
+			len(wantDocs), len(docs), docs)
+	}
+	for i, want := range wantDocs {
+		if docs[i] != want {
+			t.Errorf("ListDocuments[%d]: got %q, want %q", i, docs[i], want)
+		}
 	}
 	if err := wrapped.Load(ctx); err != nil {
 		t.Fatalf("Load failed: %v", err)


### PR DESCRIPTION
## Problem

`projectPrefixStore.ListDocuments` in `cli/watch.go` is a pure passthrough to the underlying shared vector store. In workspace mode the shared store holds every project's documents, so the indexer's scan-vs-stored diff (in `indexer.IndexAllWithBatchProgress`) compares this project's freshly-scanned files against the whole workspace's document set, treats every *other* project's document as "no longer present on disk", and runs `RemoveFile` against each one.

The removes are silent no-ops — `projectPrefixStore.DeleteByFile` re-adds the project prefix to the already-prefixed key, producing a doubly-prefixed path that never matches a stored row — so the database stays consistent. But two visible problems leak through:

1. **Misleading stats.** Every per-project scan reports the workspace's total document count under \"files removed\":

   \`\`\`
   Initial scan complete: 0 files indexed, 0 chunks created,
     8173 files removed, 24 skipped (took 1.866s)
   \`\`\`

   when this project contains 24 of those 8173 documents and nothing is actually being removed.

2. **Wasted work.** Thousands of Postgres roundtrips per scan as the indexer fires no-op `DeleteByFile` + `DeleteDocument` calls for every other project's file. With multiple workspace restarts (e.g. service restarts, container redeploys) the noise compounds.

I noticed this debugging a separate issue in a 7-project workspace; every scan was emitting \"8173 files removed\" with no underlying change.

## Fix

`ListDocuments` now filters to entries whose path begins with this project's `workspaceName/projectName/` prefix and strips the prefix before returning, so the indexer's relative-path bookkeeping aligns with what its scanner enumerates. Legitimate deletions still target the right rows because the surrounding `DeleteByFile` / `DeleteDocument` wrappers re-add the prefix.

## Test plan

`TestProjectPrefixStore_PassThroughAndGetChunks` was updated to feed a mixed-workspace listing:

\`\`\`go
listDocumentsResult: []string{
    \"ws/proj/main.go\",
    \"ws/proj/sub/file.go\",
    \"ws/other/main.go\",          // different project — filtered
    \"different-ws/proj/main.go\", // different workspace — filtered
    \"unprefixed.go\",             // no prefix — filtered
},
\`\`\`

The assertion now requires exactly `[\"main.go\", \"sub/file.go\"]` back — both filtered to this project and stripped of the prefix. The original test was asserting the buggy passthrough behaviour (`len(docs) == 2` against `[\"a\", \"b\"]`) and would fail under the fix; both pieces now align on the new contract.

`go test ./... -count=1` is clean.