### PR TITLE
fix(trace): invalidate symbol cache when the extractor version changes

### DIFF
--- a/cli/watch.go
+++ b/cli/watch.go
@@ -832,8 +832,14 @@ func runInitialScan(ctx context.Context, idx *indexer.Indexer, scanner *indexer.
 			continue
 		}
 
-		// Skip extraction when content hash matches what we already persisted.
-		if existingHash, ok := symbolStore.GetFileContentHash(fileInfo.Path); ok && existingHash == fileInfo.Hash {
+		// Skip extraction when BOTH the content hash AND the extractor
+		// version match what was persisted last time. Content alone isn't
+		// enough — a release that ships better extraction (new tree-sitter
+		// grammar, expanded regex patterns, bug-fixed query) needs to
+		// re-process unchanged files to surface the improved symbols.
+		existingHash, hashOK := symbolStore.GetFileContentHash(fileInfo.Path)
+		existingVersion, versionOK := symbolStore.GetFileExtractorVersion(fileInfo.Path)
+		if hashOK && versionOK && existingHash == fileInfo.Hash && existingVersion == extractor.Version() {
 			continue
 		}
 
@@ -842,7 +848,7 @@ func runInitialScan(ctx context.Context, idx *indexer.Indexer, scanner *indexer.
 			log.Printf("Warning: failed to extract symbols from %s: %v", fileInfo.Path, err)
 			continue
 		}
-		if err := symbolStore.SaveFileWithContentHash(ctx, fileInfo.Path, fileInfo.Hash, symbols, refs); err != nil {
+		if err := symbolStore.SaveFileWithSignature(ctx, fileInfo.Path, fileInfo.Hash, extractor.Version(), symbols, refs); err != nil {
 			log.Printf("Warning: failed to save symbols for %s: %v", fileInfo.Path, err)
 		}
 		symbolCount += len(symbols)
@@ -2130,7 +2136,7 @@ func handleFileEvent(ctx context.Context, idx *indexer.Indexer, scanner *indexer
 			symbols, refs, err := extractSymbolsWithFramework(ctx, extractor, fileInfo.Path, fileInfo.Content, processors...)
 			if err != nil {
 				log.Printf("Failed to extract symbols from %s: %v", event.Path, err)
-			} else if err := symbolStore.SaveFileWithContentHash(ctx, fileInfo.Path, fileInfo.Hash, symbols, refs); err != nil {
+			} else if err := symbolStore.SaveFileWithSignature(ctx, fileInfo.Path, fileInfo.Hash, extractor.Version(), symbols, refs); err != nil {
 				log.Printf("Failed to save symbols for %s: %v", event.Path, err)
 			} else {
 				log.Printf("Extracted %d symbols from %s", len(symbols), event.Path)

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -815,11 +815,17 @@ func runInitialScan(ctx context.Context, idx *indexer.Indexer, scanner *indexer.
 			continue
 		}
 
-		// Skip files that are unchanged since the last index run and already tracked.
+		// Skip files that are unchanged since the last index run, already
+		// tracked, and extracted by the current extractor version. The
+		// mtime fast-path must also check the extractor signature —
+		// otherwise an upgrade that ships better extraction never
+		// re-processes files whose source didn't change.
 		if !lastIndexTime.IsZero() {
 			fileModTime := time.Unix(file.ModTime, 0)
 			if (fileModTime.Before(lastIndexTime) || fileModTime.Equal(lastIndexTime)) && symbolStore.IsFileIndexed(file.Path) {
-				continue
+				if v, ok := symbolStore.GetFileExtractorVersion(file.Path); ok && v == extractor.Version() {
+					continue
+				}
 			}
 		}
 

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -832,8 +832,14 @@ func runInitialScan(ctx context.Context, idx *indexer.Indexer, scanner *indexer.
 			continue
 		}
 
-		// Skip extraction when content hash matches what we already persisted.
-		if existingHash, ok := symbolStore.GetFileContentHash(fileInfo.Path); ok && existingHash == fileInfo.Hash {
+		// Skip extraction when BOTH the content hash AND the extractor
+		// version match what was persisted last time. Content alone isn't
+		// enough — a release that ships better extraction (new tree-sitter
+		// grammar, expanded regex patterns, bug-fixed query) needs to
+		// re-process unchanged files to surface the improved symbols.
+		existingHash, hashOK := symbolStore.GetFileContentHash(fileInfo.Path)
+		existingVersion, versionOK := symbolStore.GetFileExtractorVersion(fileInfo.Path)
+		if hashOK && versionOK && existingHash == fileInfo.Hash && existingVersion == extractor.Version() {
 			continue
 		}
 
@@ -842,7 +848,7 @@ func runInitialScan(ctx context.Context, idx *indexer.Indexer, scanner *indexer.
 			log.Printf("Warning: failed to extract symbols from %s: %v", fileInfo.Path, err)
 			continue
 		}
-		if err := symbolStore.SaveFileWithContentHash(ctx, fileInfo.Path, fileInfo.Hash, symbols, refs); err != nil {
+		if err := symbolStore.SaveFileWithSignature(ctx, fileInfo.Path, fileInfo.Hash, extractor.Version(), symbols, refs); err != nil {
 			log.Printf("Warning: failed to save symbols for %s: %v", fileInfo.Path, err)
 		}
 		symbolCount += len(symbols)
@@ -2150,7 +2156,7 @@ func handleFileEvent(ctx context.Context, idx *indexer.Indexer, scanner *indexer
 			symbols, refs, err := extractSymbolsWithFramework(ctx, extractor, fileInfo.Path, fileInfo.Content, processors...)
 			if err != nil {
 				log.Printf("Failed to extract symbols from %s: %v", event.Path, err)
-			} else if err := symbolStore.SaveFileWithContentHash(ctx, fileInfo.Path, fileInfo.Hash, symbols, refs); err != nil {
+			} else if err := symbolStore.SaveFileWithSignature(ctx, fileInfo.Path, fileInfo.Hash, extractor.Version(), symbols, refs); err != nil {
 				log.Printf("Failed to save symbols for %s: %v", event.Path, err)
 			} else {
 				log.Printf("Extracted %d symbols from %s", len(symbols), event.Path)

--- a/cli/watch_framework_test.go
+++ b/cli/watch_framework_test.go
@@ -24,6 +24,7 @@ func (m *mockSymbolExtractor) ExtractAll(ctx context.Context, filePath string, c
 }
 func (m *mockSymbolExtractor) SupportedLanguages() []string { return []string{".ts"} }
 func (m *mockSymbolExtractor) Mode() string                 { return "fast" }
+func (m *mockSymbolExtractor) Version() string              { return "mock-v1" }
 
 type mockFrameworkProcessor struct{}
 

--- a/cli/watch_initialscan_test.go
+++ b/cli/watch_initialscan_test.go
@@ -95,11 +95,17 @@ func TestRunInitialScan_SkipsSymbolExtractionWhenContentHashMatches(t *testing.T
 			Language: "go",
 		},
 	}
-	if err := symbolStore.SaveFileWithContentHash(ctx, fileInfo.Path, fileInfo.Hash, sentinel, nil); err != nil {
+	// Seed using the new SaveFileWithSignature so the persisted
+	// extractor version matches what RegexExtractor.Version() returns;
+	// otherwise runInitialScan correctly re-extracts (invalidating the
+	// seeded "sentinel") because the cache predates the current
+	// extractor version. Plain SaveFileWithContentHash would simulate
+	// an old gob file that the dedup deliberately treats as stale.
+	extractor := trace.NewRegexExtractor()
+	if err := symbolStore.SaveFileWithSignature(ctx, fileInfo.Path, fileInfo.Hash, extractor.Version(), sentinel, nil); err != nil {
 		t.Fatalf("failed to seed symbol store: %v", err)
 	}
 
-	extractor := trace.NewRegexExtractor()
 	if _, err := runInitialScan(ctx, idx, scanner, extractor, symbolStore, []string{".go"}, time.Time{}, true, nil, nil); err != nil {
 		t.Fatalf("runInitialScan failed: %v", err)
 	}
@@ -564,5 +570,133 @@ func TestEmitInitialStatsSnapshot_ReportsExistingTotals(t *testing.T) {
 	}
 	if !got.Snapshot {
 		t.Fatal("expected snapshot delta to be marked as Snapshot")
+	}
+}
+
+// TestRunInitialScan_ReExtractsWhenExtractorVersionDiffers confirms the
+// dedup invalidates a cached symbol set when the persisted extractor
+// version no longer matches the running extractor — the scenario a
+// user hits after upgrading to a release that ships better symbol
+// extraction without touching their source files.
+func TestRunInitialScan_ReExtractsWhenExtractorVersionDiffers(t *testing.T) {
+	ctx := context.Background()
+	projectRoot := t.TempDir()
+
+	srcPath := filepath.Join(projectRoot, "main.go")
+	srcContent := "package main\n\nfunc real() {}\n"
+	if err := os.WriteFile(srcPath, []byte(srcContent), 0644); err != nil {
+		t.Fatalf("failed to create source file: %v", err)
+	}
+
+	ignoreMatcher, err := indexer.NewIgnoreMatcher(projectRoot, []string{}, "")
+	if err != nil {
+		t.Fatalf("failed to create ignore matcher: %v", err)
+	}
+
+	scanner := indexer.NewScanner(projectRoot, ignoreMatcher)
+	chunker := indexer.NewChunker(512, 50)
+	vecStore := store.NewGOBStore(filepath.Join(projectRoot, "index.gob"))
+	idx := indexer.NewIndexer(projectRoot, vecStore, &noOpEmbedder{}, chunker, scanner, time.Now().Add(1*time.Hour))
+
+	symbolStore := trace.NewGOBSymbolStore(filepath.Join(projectRoot, "symbols.gob"))
+	if err := symbolStore.Load(ctx); err != nil {
+		t.Fatalf("failed to load symbol store: %v", err)
+	}
+	defer symbolStore.Close()
+
+	fileInfo, err := scanner.ScanFile("main.go")
+	if err != nil {
+		t.Fatalf("failed to scan file: %v", err)
+	}
+
+	// Seed with a STALE extractor version. The content hash matches the
+	// current file, but the version recorded is a prior release. The
+	// dedup must invalidate and re-extract.
+	staleSentinel := []trace.Symbol{
+		{Name: "stale_sentinel", Kind: trace.KindFunction, File: "main.go", Line: 1, Language: "go"},
+	}
+	if err := symbolStore.SaveFileWithSignature(ctx, fileInfo.Path, fileInfo.Hash, "regex-vOLD", staleSentinel, nil); err != nil {
+		t.Fatalf("failed to seed symbol store: %v", err)
+	}
+
+	extractor := trace.NewRegexExtractor()
+	if _, err := runInitialScan(ctx, idx, scanner, extractor, symbolStore, []string{".go"}, time.Time{}, true, nil, nil); err != nil {
+		t.Fatalf("runInitialScan failed: %v", err)
+	}
+
+	// After re-extraction, the stale sentinel must be gone and the real
+	// "real" function from the source must be in the store.
+	stale, err := symbolStore.LookupSymbol(ctx, "stale_sentinel")
+	if err != nil {
+		t.Fatalf("LookupSymbol(stale_sentinel) failed: %v", err)
+	}
+	if len(stale) != 0 {
+		t.Errorf("expected stale sentinel to be invalidated, found %d entries", len(stale))
+	}
+
+	real, err := symbolStore.LookupSymbol(ctx, "real")
+	if err != nil {
+		t.Fatalf("LookupSymbol(real) failed: %v", err)
+	}
+	if len(real) == 0 {
+		t.Error("expected real to be re-extracted after version mismatch, got none")
+	}
+}
+
+// TestRunInitialScan_ReExtractsWhenExtractorVersionIsMissing confirms the
+// upgrade path from gob files written by older grepai releases that lack
+// the FileExtractorVersions field altogether — the dedup must treat the
+// cache as stale and re-extract once.
+func TestRunInitialScan_ReExtractsWhenExtractorVersionIsMissing(t *testing.T) {
+	ctx := context.Background()
+	projectRoot := t.TempDir()
+
+	srcPath := filepath.Join(projectRoot, "main.go")
+	srcContent := "package main\n\nfunc real() {}\n"
+	if err := os.WriteFile(srcPath, []byte(srcContent), 0644); err != nil {
+		t.Fatalf("failed to create source file: %v", err)
+	}
+
+	ignoreMatcher, err := indexer.NewIgnoreMatcher(projectRoot, []string{}, "")
+	if err != nil {
+		t.Fatalf("failed to create ignore matcher: %v", err)
+	}
+
+	scanner := indexer.NewScanner(projectRoot, ignoreMatcher)
+	chunker := indexer.NewChunker(512, 50)
+	vecStore := store.NewGOBStore(filepath.Join(projectRoot, "index.gob"))
+	idx := indexer.NewIndexer(projectRoot, vecStore, &noOpEmbedder{}, chunker, scanner, time.Now().Add(1*time.Hour))
+
+	symbolStore := trace.NewGOBSymbolStore(filepath.Join(projectRoot, "symbols.gob"))
+	if err := symbolStore.Load(ctx); err != nil {
+		t.Fatalf("failed to load symbol store: %v", err)
+	}
+	defer symbolStore.Close()
+
+	fileInfo, err := scanner.ScanFile("main.go")
+	if err != nil {
+		t.Fatalf("failed to scan file: %v", err)
+	}
+
+	// Use the legacy SaveFileWithContentHash, which leaves the
+	// extractor-version map empty for this file — exactly the shape of
+	// gob files produced by older grepai releases.
+	if err := symbolStore.SaveFileWithContentHash(ctx, fileInfo.Path, fileInfo.Hash, []trace.Symbol{
+		{Name: "stale_sentinel", Kind: trace.KindFunction, File: "main.go", Line: 1, Language: "go"},
+	}, nil); err != nil {
+		t.Fatalf("failed to seed symbol store: %v", err)
+	}
+
+	extractor := trace.NewRegexExtractor()
+	if _, err := runInitialScan(ctx, idx, scanner, extractor, symbolStore, []string{".go"}, time.Time{}, true, nil, nil); err != nil {
+		t.Fatalf("runInitialScan failed: %v", err)
+	}
+
+	stale, err := symbolStore.LookupSymbol(ctx, "stale_sentinel")
+	if err != nil {
+		t.Fatalf("LookupSymbol(stale_sentinel) failed: %v", err)
+	}
+	if len(stale) != 0 {
+		t.Errorf("expected stale sentinel from version-less cache to be invalidated, found %d entries", len(stale))
 	}
 }

--- a/cli/watch_initialscan_test.go
+++ b/cli/watch_initialscan_test.go
@@ -161,7 +161,12 @@ func TestRunInitialScan_SkipsIndexedFileByLastIndexTime(t *testing.T) {
 	symbolStore := trace.NewGOBSymbolStore(filepath.Join(projectRoot, "symbols.gob"))
 	defer symbolStore.Close()
 
-	if err := symbolStore.SaveFile(ctx, "main.go", []trace.Symbol{
+	// Seed with the current extractor signature: the mtime fast-path only
+	// applies when the persisted extractor version still matches. A
+	// version-less seed models a pre-upgrade cache and is covered by
+	// TestRunInitialScan_ReExtractsWhenMtimeFastPathHitsStaleVersion.
+	extractor := trace.NewRegexExtractor()
+	if err := symbolStore.SaveFileWithSignature(ctx, "main.go", "seeded", extractor.Version(), []trace.Symbol{
 		{
 			Name:     "sentinel",
 			Kind:     trace.KindFunction,
@@ -174,7 +179,6 @@ func TestRunInitialScan_SkipsIndexedFileByLastIndexTime(t *testing.T) {
 	}
 
 	lastIndexTime := time.Now().Add(1 * time.Hour)
-	extractor := trace.NewRegexExtractor()
 	if _, err := runInitialScan(ctx, idx, scanner, extractor, symbolStore, []string{".go"}, lastIndexTime, true, nil, nil); err != nil {
 		t.Fatalf("runInitialScan failed: %v", err)
 	}
@@ -698,5 +702,94 @@ func TestRunInitialScan_ReExtractsWhenExtractorVersionIsMissing(t *testing.T) {
 	}
 	if len(stale) != 0 {
 		t.Errorf("expected stale sentinel from version-less cache to be invalidated, found %d entries", len(stale))
+	}
+}
+
+// TestRunInitialScan_ReExtractsWhenMtimeFastPathHitsStaleVersion is the
+// end-to-end upgrade scenario: sources untouched (mtime older than
+// lastIndexTime), already tracked in symbols.gob, but the persisted store
+// predates the extractor-version metadata. The mtime fast-path must not
+// short-circuit — the file has to be re-extracted so the improved symbol
+// output becomes visible.
+func TestRunInitialScan_ReExtractsWhenMtimeFastPathHitsStaleVersion(t *testing.T) {
+	ctx := context.Background()
+	projectRoot := t.TempDir()
+
+	srcPath := filepath.Join(projectRoot, "main.go")
+	srcContent := "package main\n\nfunc real() {}\n"
+	if err := os.WriteFile(srcPath, []byte(srcContent), 0644); err != nil {
+		t.Fatalf("failed to create source file: %v", err)
+	}
+
+	// A real upgrade sees files whose mtime predates the last index run.
+	lastIndexTime := time.Now().Add(-1 * time.Hour)
+	oldMtime := lastIndexTime.Add(-1 * time.Hour)
+	if err := os.Chtimes(srcPath, oldMtime, oldMtime); err != nil {
+		t.Fatalf("failed to backdate source mtime: %v", err)
+	}
+
+	ignoreMatcher, err := indexer.NewIgnoreMatcher(projectRoot, []string{}, "")
+	if err != nil {
+		t.Fatalf("failed to create ignore matcher: %v", err)
+	}
+
+	scanner := indexer.NewScanner(projectRoot, ignoreMatcher)
+	chunker := indexer.NewChunker(512, 50)
+	vecStore := store.NewGOBStore(filepath.Join(projectRoot, "index.gob"))
+	idx := indexer.NewIndexer(projectRoot, vecStore, &noOpEmbedder{}, chunker, scanner, lastIndexTime)
+
+	fileInfo, err := scanner.ScanFile("main.go")
+	if err != nil || fileInfo == nil {
+		t.Fatalf("failed to scan source file: %v", err)
+	}
+
+	// Already embedded, so the vector-index side is a no-op too.
+	if err := vecStore.SaveDocument(ctx, store.Document{
+		Path:     "main.go",
+		Hash:     fileInfo.Hash,
+		ChunkIDs: []string{"c1"},
+	}); err != nil {
+		t.Fatalf("failed to seed document: %v", err)
+	}
+
+	symbolStore := trace.NewGOBSymbolStore(filepath.Join(projectRoot, "symbols.gob"))
+	if err := symbolStore.Load(ctx); err != nil {
+		t.Fatalf("failed to load symbol store: %v", err)
+	}
+	defer symbolStore.Close()
+
+	// Legacy seed: content hash present, extractor version absent — the
+	// shape of a symbols.gob written before this feature existed.
+	if err := symbolStore.SaveFileWithContentHash(ctx, fileInfo.Path, fileInfo.Hash, []trace.Symbol{
+		{Name: "stale_sentinel", Kind: trace.KindFunction, File: "main.go", Line: 1, Language: "go"},
+	}, nil); err != nil {
+		t.Fatalf("failed to seed symbol store: %v", err)
+	}
+
+	extractor := trace.NewRegexExtractor()
+	if _, err := runInitialScan(ctx, idx, scanner, extractor, symbolStore, []string{".go"}, lastIndexTime, true, nil, nil); err != nil {
+		t.Fatalf("runInitialScan failed: %v", err)
+	}
+
+	stale, err := symbolStore.LookupSymbol(ctx, "stale_sentinel")
+	if err != nil {
+		t.Fatalf("LookupSymbol(stale_sentinel) failed: %v", err)
+	}
+	if len(stale) != 0 {
+		t.Errorf("expected the version-less cache entry to be invalidated, found %d entries", len(stale))
+	}
+
+	real, err := symbolStore.LookupSymbol(ctx, "real")
+	if err != nil {
+		t.Fatalf("LookupSymbol(real) failed: %v", err)
+	}
+	if len(real) == 0 {
+		t.Error("expected real to be re-extracted despite the mtime fast-path, got none")
+	}
+
+	// And the cache must now carry the current signature, so a second
+	// scan skips cleanly instead of re-extracting forever.
+	if v, ok := symbolStore.GetFileExtractorVersion(fileInfo.Path); !ok || v != extractor.Version() {
+		t.Errorf("expected extractor version %q to be persisted, got %q (ok=%v)", extractor.Version(), v, ok)
 	}
 }

--- a/trace/extractor.go
+++ b/trace/extractor.go
@@ -26,6 +26,19 @@ func (e *RegexExtractor) Mode() string {
 	return "fast"
 }
 
+// regexExtractorVersion is bumped manually whenever the regex pattern
+// set in patterns.go is meaningfully revised. Bumping this string
+// invalidates every persisted RegexExtractor symbol cache entry on the
+// next scan, forcing fresh extraction. Use semver-ish strings ("regex-v2",
+// "regex-v2-lua-funcs") so the bump intent is visible in diffs.
+const regexExtractorVersion = "regex-v1"
+
+// Version returns the extractor's signature used for dedup
+// invalidation. See SymbolExtractor.Version.
+func (e *RegexExtractor) Version() string {
+	return regexExtractorVersion
+}
+
 // SupportedLanguages returns list of supported file extensions.
 func (e *RegexExtractor) SupportedLanguages() []string {
 	langs := make([]string, 0, len(e.patterns))

--- a/trace/extractor_ts.go
+++ b/trace/extractor_ts.go
@@ -57,6 +57,18 @@ func (e *TreeSitterExtractor) Mode() string {
 	return "precise"
 }
 
+// treeSitterExtractorVersion is bumped manually whenever the tree-sitter
+// walk logic, grammar imports, or symbol-emission code in this file change
+// in a way that affects extraction output. Bumping invalidates cached
+// symbol entries on the next scan.
+const treeSitterExtractorVersion = "treesitter-v1"
+
+// Version returns the extractor's signature used for dedup
+// invalidation. See SymbolExtractor.Version.
+func (e *TreeSitterExtractor) Version() string {
+	return treeSitterExtractorVersion
+}
+
 // SupportedLanguages returns list of supported file extensions.
 func (e *TreeSitterExtractor) SupportedLanguages() []string {
 	langs := make([]string, 0, len(e.parsers))

--- a/trace/store.go
+++ b/trace/store.go
@@ -14,18 +14,28 @@ import (
 
 // GOBSymbolStore implements SymbolStore using GOB encoding.
 type GOBSymbolStore struct {
-	indexPath         string
-	lockPath          string
-	index             *SymbolIndex
-	fileIndex         map[string]bool
-	fileContentHashes map[string]string
-	mu                sync.RWMutex
+	indexPath              string
+	lockPath               string
+	index                  *SymbolIndex
+	fileIndex              map[string]bool
+	fileContentHashes      map[string]string
+	fileExtractorVersions  map[string]string
+	mu                     sync.RWMutex
 }
 
 type gobSymbolData struct {
-	Index             SymbolIndex
-	FileIndex         map[string]bool
-	FileContentHashes map[string]string
+	Index                  SymbolIndex
+	FileIndex              map[string]bool
+	FileContentHashes      map[string]string
+	// FileExtractorVersions records the extractor.Version() value used
+	// when each file's symbols were extracted. Pairing this with the
+	// content hash lets dedup invalidate cached extractions when a new
+	// release ships better symbol coverage even though the source files
+	// themselves haven't changed. Older gob files without this field
+	// decode with a nil map; the dedup check then treats every file as
+	// "extractor version unknown" and re-extracts once, which is the
+	// correct behaviour for a one-time upgrade.
+	FileExtractorVersions  map[string]string
 }
 
 // NewGOBSymbolStore creates a new GOB-based symbol store.
@@ -39,8 +49,9 @@ func NewGOBSymbolStore(indexPath string) *GOBSymbolStore {
 			CallGraph:  []CallEdge{},
 			Version:    1,
 		},
-		fileIndex:         make(map[string]bool),
-		fileContentHashes: make(map[string]string),
+		fileIndex:             make(map[string]bool),
+		fileContentHashes:     make(map[string]string),
+		fileExtractorVersions: make(map[string]string),
 	}
 }
 
@@ -82,6 +93,7 @@ func (s *GOBSymbolStore) loadUnlocked() error {
 	s.index = &data.Index
 	s.fileIndex = data.FileIndex
 	s.fileContentHashes = data.FileContentHashes
+	s.fileExtractorVersions = data.FileExtractorVersions
 
 	if s.index.Symbols == nil {
 		s.index.Symbols = make(map[string][]Symbol)
@@ -97,6 +109,9 @@ func (s *GOBSymbolStore) loadUnlocked() error {
 	}
 	if s.fileContentHashes == nil {
 		s.fileContentHashes = make(map[string]string)
+	}
+	if s.fileExtractorVersions == nil {
+		s.fileExtractorVersions = make(map[string]string)
 	}
 
 	return nil
@@ -129,9 +144,10 @@ func (s *GOBSymbolStore) Persist(ctx context.Context) error {
 func (s *GOBSymbolStore) persistUnlocked() error {
 	s.index.UpdatedAt = time.Now()
 	data := gobSymbolData{
-		Index:             *s.index,
-		FileIndex:         s.fileIndex,
-		FileContentHashes: s.fileContentHashes,
+		Index:                 *s.index,
+		FileIndex:             s.fileIndex,
+		FileContentHashes:     s.fileContentHashes,
+		FileExtractorVersions: s.fileExtractorVersions,
 	}
 
 	tmpFile, err := os.CreateTemp(filepath.Dir(s.indexPath), filepath.Base(s.indexPath)+".tmp-*")
@@ -172,7 +188,9 @@ func (s *GOBSymbolStore) SaveFile(ctx context.Context, filePath string, symbols 
 }
 
 // SaveFileWithContentHash persists symbols/references for a file and tracks
-// the current file content hash for future cache checks.
+// the current file content hash for future cache checks. The extractor
+// version stays whatever was already stored (or empty) — call
+// SaveFileWithSignature to update both fingerprints at once.
 func (s *GOBSymbolStore) SaveFileWithContentHash(ctx context.Context, filePath string, contentHash string, symbols []Symbol, refs []Reference) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -208,6 +226,24 @@ func (s *GOBSymbolStore) SaveFileWithContentHash(ctx context.Context, filePath s
 		s.fileContentHashes[filePath] = contentHash
 	} else {
 		delete(s.fileContentHashes, filePath)
+	}
+	return nil
+}
+
+// SaveFileWithSignature persists symbols/references for a file and
+// records BOTH the content hash and the extractor version that produced
+// them. Dedup callers can then ask GetFileExtractorVersion alongside
+// GetFileContentHash and re-extract whenever either has drifted.
+func (s *GOBSymbolStore) SaveFileWithSignature(ctx context.Context, filePath string, contentHash, extractorVersion string, symbols []Symbol, refs []Reference) error {
+	if err := s.SaveFileWithContentHash(ctx, filePath, contentHash, symbols, refs); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if extractorVersion != "" {
+		s.fileExtractorVersions[filePath] = extractorVersion
+	} else {
+		delete(s.fileExtractorVersions, filePath)
 	}
 	return nil
 }
@@ -553,4 +589,16 @@ func (s *GOBSymbolStore) GetFileContentHash(filePath string) (string, bool) {
 	defer s.mu.RUnlock()
 	hash, ok := s.fileContentHashes[filePath]
 	return hash, ok
+}
+
+// GetFileExtractorVersion returns the SymbolExtractor.Version() that was
+// recorded when this file's symbols were last persisted, if known.
+// Symbol stores produced by older grepai releases lack this metadata; in
+// that case the second return is false and callers should treat the
+// cache as stale.
+func (s *GOBSymbolStore) GetFileExtractorVersion(filePath string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	version, ok := s.fileExtractorVersions[filePath]
+	return version, ok
 }

--- a/trace/store.go
+++ b/trace/store.go
@@ -14,18 +14,28 @@ import (
 
 // GOBSymbolStore implements SymbolStore using GOB encoding.
 type GOBSymbolStore struct {
-	indexPath         string
-	lockPath          string
-	index             *SymbolIndex
-	fileIndex         map[string]bool
-	fileContentHashes map[string]string
-	mu                sync.RWMutex
+	indexPath             string
+	lockPath              string
+	index                 *SymbolIndex
+	fileIndex             map[string]bool
+	fileContentHashes     map[string]string
+	fileExtractorVersions map[string]string
+	mu                    sync.RWMutex
 }
 
 type gobSymbolData struct {
 	Index             SymbolIndex
 	FileIndex         map[string]bool
 	FileContentHashes map[string]string
+	// FileExtractorVersions records the extractor.Version() value used
+	// when each file's symbols were extracted. Pairing this with the
+	// content hash lets dedup invalidate cached extractions when a new
+	// release ships better symbol coverage even though the source files
+	// themselves haven't changed. Older gob files without this field
+	// decode with a nil map; the dedup check then treats every file as
+	// "extractor version unknown" and re-extracts once, which is the
+	// correct behavior for a one-time upgrade.
+	FileExtractorVersions map[string]string
 }
 
 // NewGOBSymbolStore creates a new GOB-based symbol store.
@@ -39,8 +49,9 @@ func NewGOBSymbolStore(indexPath string) *GOBSymbolStore {
 			CallGraph:  []CallEdge{},
 			Version:    1,
 		},
-		fileIndex:         make(map[string]bool),
-		fileContentHashes: make(map[string]string),
+		fileIndex:             make(map[string]bool),
+		fileContentHashes:     make(map[string]string),
+		fileExtractorVersions: make(map[string]string),
 	}
 }
 
@@ -82,6 +93,7 @@ func (s *GOBSymbolStore) loadUnlocked() error {
 	s.index = &data.Index
 	s.fileIndex = data.FileIndex
 	s.fileContentHashes = data.FileContentHashes
+	s.fileExtractorVersions = data.FileExtractorVersions
 
 	if s.index.Symbols == nil {
 		s.index.Symbols = make(map[string][]Symbol)
@@ -97,6 +109,9 @@ func (s *GOBSymbolStore) loadUnlocked() error {
 	}
 	if s.fileContentHashes == nil {
 		s.fileContentHashes = make(map[string]string)
+	}
+	if s.fileExtractorVersions == nil {
+		s.fileExtractorVersions = make(map[string]string)
 	}
 
 	return nil
@@ -129,9 +144,10 @@ func (s *GOBSymbolStore) Persist(ctx context.Context) error {
 func (s *GOBSymbolStore) persistUnlocked() error {
 	s.index.UpdatedAt = time.Now()
 	data := gobSymbolData{
-		Index:             *s.index,
-		FileIndex:         s.fileIndex,
-		FileContentHashes: s.fileContentHashes,
+		Index:                 *s.index,
+		FileIndex:             s.fileIndex,
+		FileContentHashes:     s.fileContentHashes,
+		FileExtractorVersions: s.fileExtractorVersions,
 	}
 
 	tmpFile, err := os.CreateTemp(filepath.Dir(s.indexPath), filepath.Base(s.indexPath)+".tmp-*")
@@ -172,7 +188,9 @@ func (s *GOBSymbolStore) SaveFile(ctx context.Context, filePath string, symbols 
 }
 
 // SaveFileWithContentHash persists symbols/references for a file and tracks
-// the current file content hash for future cache checks.
+// the current file content hash for future cache checks. The extractor
+// version stays whatever was already stored (or empty) — call
+// SaveFileWithSignature to update both fingerprints at once.
 func (s *GOBSymbolStore) SaveFileWithContentHash(ctx context.Context, filePath string, contentHash string, symbols []Symbol, refs []Reference) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -208,6 +226,24 @@ func (s *GOBSymbolStore) SaveFileWithContentHash(ctx context.Context, filePath s
 		s.fileContentHashes[filePath] = contentHash
 	} else {
 		delete(s.fileContentHashes, filePath)
+	}
+	return nil
+}
+
+// SaveFileWithSignature persists symbols/references for a file and
+// records BOTH the content hash and the extractor version that produced
+// them. Dedup callers can then ask GetFileExtractorVersion alongside
+// GetFileContentHash and re-extract whenever either has drifted.
+func (s *GOBSymbolStore) SaveFileWithSignature(ctx context.Context, filePath string, contentHash, extractorVersion string, symbols []Symbol, refs []Reference) error {
+	if err := s.SaveFileWithContentHash(ctx, filePath, contentHash, symbols, refs); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if extractorVersion != "" {
+		s.fileExtractorVersions[filePath] = extractorVersion
+	} else {
+		delete(s.fileExtractorVersions, filePath)
 	}
 	return nil
 }
@@ -553,4 +589,16 @@ func (s *GOBSymbolStore) GetFileContentHash(filePath string) (string, bool) {
 	defer s.mu.RUnlock()
 	hash, ok := s.fileContentHashes[filePath]
 	return hash, ok
+}
+
+// GetFileExtractorVersion returns the SymbolExtractor.Version() that was
+// recorded when this file's symbols were last persisted, if known.
+// Symbol stores produced by older grepai releases lack this metadata; in
+// that case the second return is false and callers should treat the
+// cache as stale.
+func (s *GOBSymbolStore) GetFileExtractorVersion(filePath string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	version, ok := s.fileExtractorVersions[filePath]
+	return version, ok
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -134,6 +134,16 @@ type SymbolExtractor interface {
 
 	// Mode returns "fast" or "precise".
 	Mode() string
+
+	// Version returns an opaque token that changes whenever this
+	// extractor's output for the same input would change — for example
+	// after a grammar bump, a new query, or a release that adds new
+	// language coverage. Callers persist this alongside the file's
+	// content hash so the dedup cache invalidates on extractor
+	// upgrades; without that, a binary that ships better symbol
+	// extraction never re-runs against files whose content didn't
+	// change between releases.
+	Version() string
 }
 
 // SymbolStore persists and queries the symbol index.


### PR DESCRIPTION
## Problem

The symbol-extraction dedup in `runInitialScan` skips any file whose stored content hash matches the freshly-scanned hash:

\`\`\`go
// cli/watch.go (upstream main)
if existingHash, ok := symbolStore.GetFileContentHash(fileInfo.Path); ok && existingHash == fileInfo.Hash {
    continue
}
\`\`\`

That's right about *file content* but ignores a second axis: the extractor itself may have changed since the symbols were persisted. A release that:

- ships a new tree-sitter grammar (e.g. lands C++ symbol coverage where there was none),
- broadens the regex patterns in `patterns.go`,
- fixes a bug that was silently swallowing certain definitions,

will produce a different symbol set for the same file content. But the dedup never re-runs the extractor on files whose source didn't change across the upgrade. Result: the new extraction quality is completely invisible to existing users until they manually delete `symbols.gob` or touch every source file.

I noticed this debugging an emacs workspace where the elisp extractor was substantially upgraded — the binary was redeployed, the watcher restarted, and the symbol index stayed exactly as it was. Same shape across other languages: any change to `extractor_ts.go`'s `walkNodeForSymbols` switch or `patterns.go`'s regex tables benefits only files modified after the upgrade.

## Solution

Pair each persisted symbol entry with the extractor signature that produced it. The dedup then requires *both* the content hash and the extractor version to match before skipping.

### Interface change

\`\`\`go
type SymbolExtractor interface {
    // … existing methods …

    // Version returns an opaque token that changes whenever this
    // extractor's output for the same input would change.
    Version() string
}
\`\`\`

\`RegexExtractor\` returns \`\"regex-v1\"\`; \`TreeSitterExtractor\` returns \`\"treesitter-v1\"\`. The convention is documented inline: bump the constant manually when symbol output changes meaningfully. Future releases that add a language or fix an extractor bump to \`regex-v2\`, \`treesitter-v2-lua\`, etc.

### Storage change

\`GOBSymbolStore\` grows a parallel \`FileExtractorVersions map[string]string\` next to the existing \`FileContentHashes\`. A new \`SaveFileWithSignature\` writes both fingerprints atomically; \`GetFileExtractorVersion\` reads them back. The legacy \`SaveFileWithContentHash\` stays for backwards-compat — old call sites keep working but the dedup will treat their entries as \"version unknown\" and re-extract once.

\`gob\` decoding is backwards compatible: older symbols.gob files without the new field decode cleanly with \`FileExtractorVersions == nil\`. The dedup treats this as a cache miss → one-time re-extraction → cache updates to the current version. Subsequent scans skip cleanly.

### Dedup change

\`\`\`go
existingHash, hashOK := symbolStore.GetFileContentHash(fileInfo.Path)
existingVersion, versionOK := symbolStore.GetFileExtractorVersion(fileInfo.Path)
if hashOK && versionOK && existingHash == fileInfo.Hash && existingVersion == extractor.Version() {
    continue
}
\`\`\`

Same logic flows into the fsnotify single-file update path (\`handleFileEvent\`) so the cache stays consistent across both startup-scan and live-edit flows.

## Test plan

- Existing \`TestRunInitialScan_SkipsSymbolExtractionWhenContentHashMatches\` is updated to seed via \`SaveFileWithSignature\` (matching the new contract). The original \`SaveFileWithContentHash\` seed now models the legacy-cache case and would correctly trigger a re-extract.
- New \`TestRunInitialScan_ReExtractsWhenExtractorVersionDiffers\` seeds a stale \`\"regex-vOLD\"\` and asserts the sentinel symbol is invalidated + the source's real symbol is re-extracted.
- New \`TestRunInitialScan_ReExtractsWhenExtractorVersionIsMissing\` seeds via the legacy \`SaveFileWithContentHash\` (simulating an old gob file with no extractor-version metadata) and asserts the same invalidate-and-re-extract behaviour.
- Mock \`SymbolExtractor\` implementations in tests grow \`Version()\`.

\`go test ./...\` is clean across the entire module.

## Migration notes

- First scan after upgrade re-extracts every file that's still in the symbol store. For a workspace with, say, 100k files this is a one-time cost on the order of a few minutes (extraction is fast; no embedding involved). Subsequent scans dedup cleanly.
- Bump the version string in \`extractor.go\` / \`extractor_ts.go\` when shipping changes to symbol extraction that should invalidate cached output. The bump is the canonical \"this release wants symbol re-extraction\" signal.