### PR TITLE
fix(embedder): prevent OpenAI 300k token limit errors in batch embedding

### DIFF
--- a/embedder/batch.go
+++ b/embedder/batch.go
@@ -5,16 +5,15 @@ package embedder
 const MaxBatchSize = 2000
 
 // MaxBatchTokens is the maximum total tokens per OpenAI embedding API batch.
-// OpenAI has a 300,000 token limit. We use 280,000 for safety margin.
-const MaxBatchTokens = 280000
+// OpenAI has a 300,000 token limit. We use 250,000 for safety margin since
+// token estimation is approximate.
+const MaxBatchTokens = 250000
 
 // EstimateTokens estimates the token count for a text string.
-// Uses a conservative estimate of ~4 characters per token for English text.
-// This is intentionally conservative to avoid hitting API limits.
+// Code/CSS/HTML tokenizes at ~2.5-3 chars per token due to special characters
+// and short identifiers. We use 3 chars/token to avoid exceeding API limits.
 func EstimateTokens(text string) int {
-	// Rough estimate: 1 token ≈ 4 characters for English text
-	// Use 3.5 to be more conservative
-	return (len(text) + 3) / 4 // Round up
+	return (len(text) + 2) / 3
 }
 
 // BatchEntry represents a single chunk with metadata for tracking its source.

--- a/embedder/batch_test.go
+++ b/embedder/batch_test.go
@@ -392,10 +392,10 @@ func TestEstimateTokens(t *testing.T) {
 		{"a", 1},
 		{"ab", 1},
 		{"abc", 1},
-		{"abcd", 1},
+		{"abcd", 2},                     // 4 chars -> 2 tokens (ceil(4/3))
 		{"abcde", 2},                    // 5 chars -> 2 tokens
-		{"hello world", 3},              // 11 chars -> 3 tokens
-		{string(make([]byte, 100)), 25}, // 100 chars -> 25 tokens
+		{"hello world", 4},              // 11 chars -> 4 tokens (ceil(11/3))
+		{string(make([]byte, 100)), 34}, // 100 chars -> 34 tokens (ceil(100/3))
 	}
 
 	for _, tt := range tests {
@@ -408,8 +408,8 @@ func TestEstimateTokens(t *testing.T) {
 
 func TestFormBatches_TokenLimit(t *testing.T) {
 	// Create chunks that are large enough to trigger token limit
-	// Each chunk will be ~10000 chars -> ~2500 tokens
-	// With MaxBatchTokens = 280000, we can fit ~112 such chunks per batch
+	// Each chunk will be ~10000 chars -> ~3334 tokens (10000/3)
+	// With MaxBatchTokens = 250000, we can fit ~75 such chunks per batch
 	largeChunk := string(make([]byte, 10000))
 
 	// Create 200 large chunks - should be split into multiple batches by token limit

--- a/embedder/errors.go
+++ b/embedder/errors.go
@@ -33,6 +33,29 @@ func NewContextLengthError(chunkIndex, estimatedTokens, maxTokens int, message s
 	}
 }
 
+// BatchError wraps an embedding error with the file indices that were in the failing batch.
+type BatchError struct {
+	FileIndices []int
+	Err         error
+}
+
+func (e *BatchError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *BatchError) Unwrap() error {
+	return e.Err
+}
+
+// AsBatchError extracts a BatchError from an error chain.
+func AsBatchError(err error) *BatchError {
+	var batchErr *BatchError
+	if errors.As(err, &batchErr) {
+		return batchErr
+	}
+	return nil
+}
+
 // IsContextLengthError checks if an error is or wraps a ContextLengthError.
 func IsContextLengthError(err error) bool {
 	var ctxErr *ContextLengthError

--- a/embedder/openai.go
+++ b/embedder/openai.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -252,7 +253,8 @@ func (e *OpenAIEmbedder) EmbedBatches(ctx context.Context, batches []Batch, prog
 		g.Go(func() error {
 			embeddings, err := e.embedBatchWithRetry(ctx, batch, len(batches), totalChunks, &completedChunks, progress)
 			if err != nil {
-				return err
+				fileIndices := batchFileIndices(batch)
+				return &BatchError{FileIndices: fileIndices, Err: err}
 			}
 			results[batch.Index] = BatchResult{
 				BatchIndex: batch.Index,
@@ -267,6 +269,19 @@ func (e *OpenAIEmbedder) EmbedBatches(ctx context.Context, batches []Batch, prog
 	}
 
 	return results, nil
+}
+
+func batchFileIndices(batch Batch) []int {
+	seen := make(map[int]bool)
+	for _, entry := range batch.Entries {
+		seen[entry.FileIndex] = true
+	}
+	indices := make([]int, 0, len(seen))
+	for idx := range seen {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+	return indices
 }
 
 // embedBatchWithRetry embeds a single batch with retry logic for retryable errors.

--- a/embedder/openai_batch_test.go
+++ b/embedder/openai_batch_test.go
@@ -3,6 +3,7 @@ package embedder
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -320,10 +321,16 @@ func TestOpenAIEmbedder_EmbedBatches_FailOn4xx(t *testing.T) {
 		t.Fatal("expected error for 401 response")
 	}
 
-	// Verify it's identified as non-retryable
-	retryErr, ok := err.(*RetryableError)
-	if !ok {
-		t.Fatalf("expected RetryableError, got %T", err)
+	// Verify it's wrapped in a BatchError with file indices
+	batchErr := AsBatchError(err)
+	if batchErr == nil {
+		t.Fatalf("expected BatchError wrapper, got %T", err)
+	}
+
+	// Verify the underlying error is a non-retryable RetryableError
+	var retryErr *RetryableError
+	if !errors.As(err, &retryErr) {
+		t.Fatalf("expected RetryableError in chain, got %T", err)
 	}
 	if retryErr.Retryable {
 		t.Error("401 error should not be retryable")
@@ -742,10 +749,19 @@ func TestOpenAIEmbedder_EmbedBatches_ParallelBatchFailure(t *testing.T) {
 		t.Fatal("expected error when batch fails")
 	}
 
-	// Verify the error is from the failed batch
-	retryErr, ok := err.(*RetryableError)
-	if !ok {
-		t.Fatalf("expected RetryableError, got %T: %v", err, err)
+	// Verify it's wrapped in a BatchError with the correct file indices
+	batchErr := AsBatchError(err)
+	if batchErr == nil {
+		t.Fatalf("expected BatchError wrapper, got %T: %v", err, err)
+	}
+	if len(batchErr.FileIndices) == 0 {
+		t.Error("expected file indices in BatchError")
+	}
+
+	// Verify the underlying error is from the failed batch
+	var retryErr *RetryableError
+	if !errors.As(err, &retryErr) {
+		t.Fatalf("expected RetryableError in chain, got: %v", err)
 	}
 	if retryErr.StatusCode != http.StatusUnauthorized {
 		t.Errorf("expected status 401, got %d", retryErr.StatusCode)

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -421,6 +421,17 @@ func (idx *Indexer) indexFilesBatched(
 		batches := embedder.FormBatches(remainingFileChunks)
 		results, err := batchEmb.EmbedBatches(ctx, batches, wrapBatchProgress(onProgress))
 		if err != nil {
+			if batchErr := embedder.AsBatchError(err); batchErr != nil {
+				log.Printf("Batch embedding failed. Files in the failing batch:")
+				for _, fileIdx := range batchErr.FileIndices {
+					for _, fd := range remainingFileData {
+						if fd.fileIndex == fileIdx {
+							log.Printf("  %s (%d chunks)", fd.file.Path, len(fd.chunkInfos))
+							break
+						}
+					}
+				}
+			}
 			return filesIndexed, chunksCreated, fmt.Errorf("failed to embed batches: %w", err)
 		}
 


### PR DESCRIPTION
## Summary

- Fixes batch token estimation that underestimated code/CSS/HTML token counts (~4 chars/token → ~3 chars/token), causing batches to exceed OpenAI's 300,000 token request limit
- Reduces `MaxBatchTokens` from 280k to 250k for additional safety margin
- Adds `BatchError` type that surfaces which files are in a failing batch, making it easy to identify problematic files when errors do occur

## Root Cause

The `EstimateTokens` function used `len(text) / 4` (~4 chars per token), which is reasonable for English prose but too optimistic for CSS/HTML/code with special characters and short identifiers (which tokenize at ~2.5-3 chars per token). This caused batches estimated at 280k tokens to actually contain 300k+ real tokens, hitting OpenAI's hard limit.

## Test plan

- [x] All existing embedder and indexer tests pass
- [x] Tested on a large Angular project with heavy CSS/font-awesome content that previously failed
- [ ] Verify no regressions on projects that previously indexed successfully (batches will be slightly smaller, requiring more API calls)

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)