### PR TITLE
fix(store): write index atomically and recover from corrupted index files

### DIFF
--- a/store/gob.go
+++ b/store/gob.go
@@ -176,12 +176,32 @@ func (s *GOBStore) loadUnlocked() error {
 		// wedge grepai in a permanent error loop: the index is a rebuildable
 		// cache. Quarantine the bad file and start from an empty index so the
 		// next scan re-creates it.
+		// Close before renaming: Windows cannot rename a file that is open.
 		_ = file.Close()
 		corruptPath := s.indexPath + ".corrupt"
-		if renameErr := fileutil.ReplaceFileAtomically(s.indexPath, corruptPath); renameErr != nil {
-			return fmt.Errorf("failed to decode index: %w", err)
+		// Plain os.Rename, NOT ReplaceFileAtomically: its remove-then-rename
+		// fallback would delete a .corrupt file freshly quarantined by a
+		// concurrent process (Load holds only a shared lock).
+		renameErr := os.Rename(s.indexPath, corruptPath)
+		if renameErr != nil && !os.IsNotExist(renameErr) {
+			// os.Rename does not overwrite an existing file on Windows; drop a
+			// stale quarantine from a previous recovery and retry once.
+			_ = os.Remove(corruptPath)
+			renameErr = os.Rename(s.indexPath, corruptPath)
 		}
-		log.Printf("Warning: index file %s is corrupted (%v); moved it to %s and starting with an empty index — it will be rebuilt on the next scan", s.indexPath, err, corruptPath)
+		switch {
+		case renameErr == nil:
+			log.Printf("Warning: index file %s is corrupted (%v); moved it to %s and starting with an empty index — it will be rebuilt on the next scan", s.indexPath, err, corruptPath)
+		case os.IsNotExist(renameErr):
+			// A concurrent process hit the same corruption and already
+			// quarantined the file; adopt its recovery instead of resurfacing
+			// the decode error.
+			log.Printf("Warning: index file %s is corrupted (%v); already quarantined by a concurrent process — starting with an empty index", s.indexPath, err)
+		default:
+			// Self-heal failed (e.g. read-only directory): keep the fatal
+			// behavior but surface the failed quarantine so it is diagnosable.
+			return fmt.Errorf("failed to decode index: %w (quarantine to %s failed: %v)", err, corruptPath, renameErr)
+		}
 		s.chunks = make(map[string]Chunk)
 		s.documents = make(map[string]Document)
 		return nil

--- a/store/gob.go
+++ b/store/gob.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
+	"log"
 	"math"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -170,7 +172,19 @@ func (s *GOBStore) loadUnlocked() error {
 	var data gobData
 	decoder := gob.NewDecoder(file)
 	if err := decoder.Decode(&data); err != nil {
-		return fmt.Errorf("failed to decode index: %w", err)
+		// A truncated/corrupted index (e.g. after an unclean shutdown) must not
+		// wedge grepai in a permanent error loop: the index is a rebuildable
+		// cache. Quarantine the bad file and start from an empty index so the
+		// next scan re-creates it.
+		_ = file.Close()
+		corruptPath := s.indexPath + ".corrupt"
+		if renameErr := fileutil.ReplaceFileAtomically(s.indexPath, corruptPath); renameErr != nil {
+			return fmt.Errorf("failed to decode index: %w", err)
+		}
+		log.Printf("Warning: index file %s is corrupted (%v); moved it to %s and starting with an empty index — it will be rebuilt on the next scan", s.indexPath, err, corruptPath)
+		s.chunks = make(map[string]Chunk)
+		s.documents = make(map[string]Document)
+		return nil
 	}
 
 	s.chunks = data.Chunks
@@ -214,22 +228,42 @@ func (s *GOBStore) Persist(ctx context.Context) error {
 }
 
 // persistUnlocked performs the actual persist without any locking.
+// It writes to a temp file and atomically replaces the index so that an
+// unclean shutdown mid-write can never leave a truncated index behind.
 func (s *GOBStore) persistUnlocked() error {
-	file, err := os.Create(s.indexPath)
-	if err != nil {
-		return fmt.Errorf("failed to create index file: %w", err)
-	}
-	defer file.Close()
-
 	data := gobData{
 		Chunks:    s.chunks,
 		Documents: s.documents,
 	}
 
-	encoder := gob.NewEncoder(file)
-	if err := encoder.Encode(data); err != nil {
+	tmpFile, err := os.CreateTemp(filepath.Dir(s.indexPath), filepath.Base(s.indexPath)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create index temp file: %w", err)
+	}
+
+	tmpPath := tmpFile.Name()
+	cleanupTemp := true
+	defer func() {
+		if cleanupTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := gob.NewEncoder(tmpFile).Encode(data); err != nil {
+		_ = tmpFile.Close()
 		return fmt.Errorf("failed to encode index: %w", err)
 	}
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("failed to sync index temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close index temp file: %w", err)
+	}
+	if err := fileutil.ReplaceFileAtomically(tmpPath, s.indexPath); err != nil {
+		return fmt.Errorf("failed to replace index file: %w", err)
+	}
+	cleanupTemp = false
 
 	return nil
 }

--- a/store/gob_test.go
+++ b/store/gob_test.go
@@ -444,3 +444,117 @@ func TestGOBStore_FileLocking(t *testing.T) {
 		t.Errorf("Expected chunk ID c1, got %s", chunks[0].ID)
 	}
 }
+
+func TestGOBStore_LoadGarbageIndexRecovers(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+
+	if err := os.WriteFile(indexPath, []byte("not a gob file"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	store := NewGOBStore(indexPath)
+	if err := store.Load(context.Background()); err != nil {
+		t.Fatalf("Load should recover from a corrupted index, got: %v", err)
+	}
+
+	numDocs, numChunks := store.Stats()
+	if numDocs != 0 || numChunks != 0 {
+		t.Fatalf("Expected empty store after recovery, got %d docs / %d chunks", numDocs, numChunks)
+	}
+
+	if _, err := os.Stat(indexPath); !os.IsNotExist(err) {
+		t.Fatal("Expected corrupted index file to be moved aside")
+	}
+	if _, err := os.Stat(indexPath + ".corrupt"); err != nil {
+		t.Fatalf("Expected quarantined .corrupt file to exist: %v", err)
+	}
+}
+
+func TestGOBStore_LoadTruncatedIndexRecovers(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+	ctx := context.Background()
+
+	s1 := NewGOBStore(indexPath)
+	if err := s1.SaveChunks(ctx, []Chunk{
+		{ID: "c1", FilePath: "a.go", Content: "hello", Vector: []float32{1, 2, 3}},
+	}); err != nil {
+		t.Fatalf("SaveChunks failed: %v", err)
+	}
+	if err := s1.Persist(ctx); err != nil {
+		t.Fatalf("Persist failed: %v", err)
+	}
+
+	// Simulate an unclean shutdown mid-write: truncate the index to half its size.
+	info, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	if err := os.Truncate(indexPath, info.Size()/2); err != nil {
+		t.Fatalf("Truncate failed: %v", err)
+	}
+
+	s2 := NewGOBStore(indexPath)
+	if err := s2.Load(ctx); err != nil {
+		t.Fatalf("Load should recover from a truncated index, got: %v", err)
+	}
+
+	numDocs, numChunks := s2.Stats()
+	if numDocs != 0 || numChunks != 0 {
+		t.Fatalf("Expected empty store after recovery, got %d docs / %d chunks", numDocs, numChunks)
+	}
+
+	// A recovered (empty) store must be able to persist and reload cleanly.
+	if err := s2.Persist(ctx); err != nil {
+		t.Fatalf("Persist after recovery failed: %v", err)
+	}
+	s3 := NewGOBStore(indexPath)
+	if err := s3.Load(ctx); err != nil {
+		t.Fatalf("Load after recovery persist failed: %v", err)
+	}
+}
+
+func TestGOBStore_PersistIsAtomicAndLeavesNoTempFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+	ctx := context.Background()
+
+	store := NewGOBStore(indexPath)
+	if err := store.SaveChunks(ctx, []Chunk{
+		{ID: "c1", FilePath: "a.go", Content: "v1", Vector: []float32{1}},
+	}); err != nil {
+		t.Fatalf("SaveChunks failed: %v", err)
+	}
+	if err := store.Persist(ctx); err != nil {
+		t.Fatalf("First persist failed: %v", err)
+	}
+
+	// Overwrite an existing index (the rename-over path).
+	if err := store.SaveChunks(ctx, []Chunk{
+		{ID: "c2", FilePath: "b.go", Content: "v2", Vector: []float32{2}},
+	}); err != nil {
+		t.Fatalf("SaveChunks failed: %v", err)
+	}
+	if err := store.Persist(ctx); err != nil {
+		t.Fatalf("Second persist failed: %v", err)
+	}
+
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "index.gob" && e.Name() != "index.gob.lock" {
+			t.Errorf("Unexpected leftover file after persist: %s", e.Name())
+		}
+	}
+
+	loaded := NewGOBStore(indexPath)
+	if err := loaded.Load(ctx); err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if _, numChunks := loaded.Stats(); numChunks != 2 {
+		t.Fatalf("Expected 2 chunks after reload, got %d", numChunks)
+	}
+}

--- a/store/gob_test.go
+++ b/store/gob_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -486,7 +487,9 @@ func TestGOBStore_LoadTruncatedIndexRecovers(t *testing.T) {
 		t.Fatalf("Persist failed: %v", err)
 	}
 
-	// Simulate an unclean shutdown mid-write: truncate the index to half its size.
+	// Simulate a torn index file — what pre-fix versions left behind after an
+	// unclean shutdown mid-write (the atomic persist now prevents grepai itself
+	// from producing one, but existing installs and external truncation can).
 	info, err := os.Stat(indexPath)
 	if err != nil {
 		t.Fatalf("Stat failed: %v", err)
@@ -515,7 +518,7 @@ func TestGOBStore_LoadTruncatedIndexRecovers(t *testing.T) {
 	}
 }
 
-func TestGOBStore_PersistIsAtomicAndLeavesNoTempFiles(t *testing.T) {
+func TestGOBStore_PersistLeavesNoTempFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	indexPath := filepath.Join(tmpDir, "index.gob")
 	ctx := context.Background()
@@ -556,5 +559,139 @@ func TestGOBStore_PersistIsAtomicAndLeavesNoTempFiles(t *testing.T) {
 	}
 	if _, numChunks := loaded.Stats(); numChunks != 2 {
 		t.Fatalf("Expected 2 chunks after reload, got %d", numChunks)
+	}
+}
+
+func TestGOBStore_LoadZeroByteIndexRecovers(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+
+	// A zero-byte index is the most common artifact of the pre-fix truncation bug.
+	if err := os.WriteFile(indexPath, nil, 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	store := NewGOBStore(indexPath)
+	if err := store.Load(context.Background()); err != nil {
+		t.Fatalf("Load should recover from a zero-byte index, got: %v", err)
+	}
+	if numDocs, numChunks := store.Stats(); numDocs != 0 || numChunks != 0 {
+		t.Fatalf("Expected empty store after recovery, got %d docs / %d chunks", numDocs, numChunks)
+	}
+	if _, err := os.Stat(indexPath + ".corrupt"); err != nil {
+		t.Fatalf("Expected quarantined .corrupt file to exist: %v", err)
+	}
+}
+
+func TestGOBStore_LoadCorruptIndexReplacesStaleQuarantine(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+	corruptPath := indexPath + ".corrupt"
+
+	if err := os.WriteFile(corruptPath, []byte("stale quarantine"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	if err := os.WriteFile(indexPath, []byte("fresh garbage"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	store := NewGOBStore(indexPath)
+	if err := store.Load(context.Background()); err != nil {
+		t.Fatalf("Load should recover when a stale .corrupt already exists, got: %v", err)
+	}
+
+	got, err := os.ReadFile(corruptPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if string(got) != "fresh garbage" {
+		t.Fatalf("Expected quarantine to hold the latest corrupt bytes, got %q", got)
+	}
+}
+
+func TestGOBStore_ConcurrentLoadsOfCorruptIndexAllRecover(t *testing.T) {
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+
+	if err := os.WriteFile(indexPath, []byte("not a gob file"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	// Load holds only a shared lock, so several readers (watch daemon retry
+	// loop + a search / MCP call) can hit the recovery branch at once — the
+	// exact issue #178 scenario. Losers of the quarantine rename must adopt
+	// the winner's recovery instead of failing, and must not delete the
+	// winner's .corrupt evidence.
+	const readers = 8
+	start := make(chan struct{})
+	errs := make(chan error, readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			<-start
+			errs <- NewGOBStore(indexPath).Load(context.Background())
+		}()
+	}
+	close(start)
+	for i := 0; i < readers; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("Concurrent Load should recover, got: %v", err)
+		}
+	}
+	if _, err := os.Stat(indexPath + ".corrupt"); err != nil {
+		t.Fatalf("Expected .corrupt evidence to survive concurrent recovery: %v", err)
+	}
+}
+
+func TestGOBStore_FailedPersistPreservesPreviousIndex(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory write-permission semantics differ on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	tmpDir := t.TempDir()
+	indexPath := filepath.Join(tmpDir, "index.gob")
+	ctx := context.Background()
+
+	s1 := NewGOBStore(indexPath)
+	if err := s1.SaveChunks(ctx, []Chunk{
+		{ID: "c1", FilePath: "a.go", Content: "v1", Vector: []float32{1}},
+	}); err != nil {
+		t.Fatalf("SaveChunks failed: %v", err)
+	}
+	if err := s1.Persist(ctx); err != nil {
+		t.Fatalf("First persist failed: %v", err)
+	}
+
+	// Make the directory unwritable so the next persist fails at CreateTemp —
+	// the previously persisted index must survive a failed write untouched.
+	if err := os.Chmod(tmpDir, 0o555); err != nil {
+		t.Fatalf("Chmod failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(tmpDir, 0o755) })
+
+	if err := s1.SaveChunks(ctx, []Chunk{
+		{ID: "c2", FilePath: "b.go", Content: "v2", Vector: []float32{2}},
+	}); err != nil {
+		t.Fatalf("SaveChunks failed: %v", err)
+	}
+	if err := s1.Persist(ctx); err == nil {
+		t.Fatal("Persist into a read-only directory should fail")
+	}
+
+	if err := os.Chmod(tmpDir, 0o755); err != nil {
+		t.Fatalf("Chmod failed: %v", err)
+	}
+	s2 := NewGOBStore(indexPath)
+	if err := s2.Load(ctx); err != nil {
+		t.Fatalf("Load after failed persist failed: %v", err)
+	}
+	chunks, err := s2.GetAllChunks(ctx)
+	if err != nil {
+		t.Fatalf("GetAllChunks failed: %v", err)
+	}
+	if len(chunks) != 1 || chunks[0].ID != "c1" {
+		t.Fatalf("Expected only the pre-failure chunk c1 to survive, got %+v", chunks)
 	}
 }


### PR DESCRIPTION
## Problem

Fixes #178. `GOBStore.Persist` wrote the index with `gob.NewEncoder(file).Encode(...)` directly into `index.gob`. Any crash, OOM-kill, or power loss mid-write left a truncated file behind, and every subsequent command failed forever with:

```
failed to load index: failed to decode index: unexpected EOF
```

There was no self-heal: the only way out was to manually delete `.grepai/index.gob` in the project **and in every linked worktree** (the watcher indexes them all). Multi-worktree setups made this a recurring, hard-to-diagnose breakage for both humans and AI agents using grepai via MCP.

## Fix (two independent layers)

**1. Atomic persist — the root cause.** `persistUnlocked` now writes to a `CreateTemp` file in the same directory, then `Sync → Close → rename` over `index.gob`. A crash mid-write can no longer produce a truncated index; the previous good index survives any failed persist. This is the exact pattern already used by `trace/store.go` and `rpg/store_gob.go` — the main index was the only store missing it.

**2. Corruption recovery — heals existing damage.** If `loadUnlocked` fails to decode (indexes truncated by previous versions, disk issues), it quarantines the bad file to `index.gob.corrupt` (evidence preserved for debugging, never silently deleted), logs a loud warning with the path and the next step, and starts with an empty index so the next scan rebuilds it.

The recovery path is race-safe: `Load` holds only a *shared* flock, so two processes (the `watch` daemon retry loop plus a `search`/MCP call — the exact #178 scenario) can hit the recovery branch concurrently. The quarantine uses plain `os.Rename`; a loser whose rename fails with `IsNotExist` adopts the winner's recovery instead of resurfacing the fatal error, and can never delete the winner's `.corrupt` evidence. If the quarantine genuinely fails (e.g. read-only directory), the returned error now wraps **both** the decode and rename errors so a failed self-heal is diagnosable.

## Tests

- garbage index → recovers empty, `.corrupt` quarantined
- realistically truncated index (torn write) → recovers, then persists/reloads cleanly
- zero-byte index (the most common artifact of the old bug) → recovers
- 8 concurrent `Load`s on the same corrupt index → all recover, evidence survives (`-race`)
- failed persist (read-only dir) → previous index survives untouched
- stale `.corrupt` from an earlier recovery → replaced by the newest evidence
- overwrite path leaves no `index.gob.tmp-*` files behind

## Known limitations (intentionally out of scope)

- Read-only consumers (`search`, `status`, MCP) recover to an *empty* index and log a warning, but don't trigger a rebuild themselves — only the watcher rebuilds. A follow-up could suggest `grepai watch` in the CLI output when recovery fired.
- A decode failure caused by a transient read error (NFS hiccup, failing disk) is treated as corruption; the data is preserved in `.corrupt` and can be restored manually.
- Orphaned `index.gob.tmp-*` from a crash mid-persist are not swept on startup (same behavior as `trace/store.go` and `rpg/store_gob.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
