### PR TITLE
feat(watch): add config option to disable linked worktree discovery

### DIFF
--- a/cli/watch.go
+++ b/cli/watch.go
@@ -861,6 +861,7 @@ func runInitialScan(ctx context.Context, idx *indexer.Indexer, scanner *indexer.
 
 // discoverWorktreesForWatch discovers linked worktrees and auto-initializes them.
 // Only discovers from the main worktree; returns nil for linked worktrees.
+// Discovery can be disabled with watch.discover_worktrees: false in config.
 func discoverWorktreesForWatch(projectRoot string) []string {
 	projectRootCanonical := canonicalPath(projectRoot)
 
@@ -871,6 +872,12 @@ func discoverWorktreesForWatch(projectRoot string) []string {
 
 	// Only the main worktree discovers linked worktrees
 	if gitInfo.IsWorktree {
+		return nil
+	}
+
+	// Respect the opt-out. Re-checked on every discovery pass, so toggling the
+	// option takes effect on the supervisor's next reconcile without a restart.
+	if cfg, err := config.Load(projectRoot); err == nil && !cfg.Watch.WorktreeDiscoveryEnabled() {
 		return nil
 	}
 

--- a/cli/watch.go
+++ b/cli/watch.go
@@ -877,7 +877,19 @@ func discoverWorktreesForWatch(projectRoot string) []string {
 
 	// Respect the opt-out. Re-checked on every discovery pass, so toggling the
 	// option takes effect on the supervisor's next reconcile without a restart.
-	if cfg, err := config.Load(projectRoot); err == nil && !cfg.Watch.WorktreeDiscoveryEnabled() {
+	// Only the main worktree's config is consulted: discovery never runs from
+	// linked worktrees, so the key is ignored in their config copies.
+	cfg, err := config.Load(projectRoot)
+	if err != nil {
+		// Fail closed: a torn/invalid config (e.g. saved mid-edit between two
+		// reconcile passes) must not re-enable discovery behind the user's
+		// back — discovery auto-initializes worktrees (creates .grepai/,
+		// edits .gitignore), which is not free to undo. Skipping a pass is:
+		// the next successful load resumes discovery.
+		log.Printf("Warning: skipping worktree discovery: failed to load config for %s: %v", projectRoot, err)
+		return nil
+	}
+	if !cfg.Watch.WorktreeDiscoveryEnabled() {
 		return nil
 	}
 

--- a/cli/watch_worktree_discovery_test.go
+++ b/cli/watch_worktree_discovery_test.go
@@ -85,3 +85,23 @@ func TestDiscoverWorktreesForWatch_LinkedWorktreeDoesNotDiscoverSiblings(t *test
 		t.Fatalf("discoverWorktreesForWatch() returned %d worktrees for linked worktree, want 0", len(got))
 	}
 }
+
+func TestDiscoverWorktreesForWatch_DisabledByConfig(t *testing.T) {
+	mainRepo, worktreePath := setupMainRepoForWorktreeDiscovery(t)
+
+	configPath := filepath.Join(mainRepo, ".grepai", "config.yaml")
+	configYAML := "watch:\n  debounce_ms: 500\n  discover_worktrees: false\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("failed to write config.yaml: %v", err)
+	}
+
+	got := discoverWorktreesForWatch(mainRepo)
+	if len(got) != 0 {
+		t.Fatalf("discoverWorktreesForWatch() returned %d worktrees with discovery disabled, want 0", len(got))
+	}
+
+	// Discovery must not have auto-initialized the linked worktree either.
+	if _, err := os.Stat(filepath.Join(worktreePath, ".grepai")); !os.IsNotExist(err) {
+		t.Fatalf("expected no .grepai auto-init in linked worktree when discovery is disabled")
+	}
+}

--- a/cli/watch_worktree_discovery_test.go
+++ b/cli/watch_worktree_discovery_test.go
@@ -105,3 +105,23 @@ func TestDiscoverWorktreesForWatch_DisabledByConfig(t *testing.T) {
 		t.Fatalf("expected no .grepai auto-init in linked worktree when discovery is disabled")
 	}
 }
+
+func TestDiscoverWorktreesForWatch_UnreadableConfigFailsClosed(t *testing.T) {
+	mainRepo, worktreePath := setupMainRepoForWorktreeDiscovery(t)
+
+	// A torn/invalid config (e.g. saved mid-edit between reconcile passes)
+	// must not re-enable discovery: auto-init has side effects (creates
+	// .grepai/, edits .gitignore) that skipping a pass does not.
+	configPath := filepath.Join(mainRepo, ".grepai", "config.yaml")
+	if err := os.WriteFile(configPath, []byte("watch: [broken\n"), 0644); err != nil {
+		t.Fatalf("failed to write config.yaml: %v", err)
+	}
+
+	got := discoverWorktreesForWatch(mainRepo)
+	if len(got) != 0 {
+		t.Fatalf("discoverWorktreesForWatch() returned %d worktrees with unreadable config, want 0 (fail closed)", len(got))
+	}
+	if _, err := os.Stat(filepath.Join(worktreePath, ".grepai")); !os.IsNotExist(err) {
+		t.Fatalf("expected no .grepai auto-init in linked worktree when config load fails")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -284,6 +284,16 @@ type WatchConfig struct {
 	RPGDerivedDebounceMs        int       `yaml:"rpg_derived_debounce_ms,omitempty"`
 	RPGFullReconcileIntervalSec int       `yaml:"rpg_full_reconcile_interval_sec,omitempty"`
 	RPGMaxDirtyFilesPerBatch    int       `yaml:"rpg_max_dirty_files_per_batch,omitempty"`
+	// DiscoverWorktrees controls automatic discovery (and watching) of linked
+	// git worktrees. A pointer is used so that configs without the key keep
+	// the historical default (enabled).
+	DiscoverWorktrees *bool `yaml:"discover_worktrees,omitempty"`
+}
+
+// WorktreeDiscoveryEnabled reports whether linked git worktrees should be
+// auto-discovered and watched. Defaults to true when the option is not set.
+func (w WatchConfig) WorktreeDiscoveryEnabled() bool {
+	return w.DiscoverWorktrees == nil || *w.DiscoverWorktrees
 }
 
 type TraceConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -286,7 +286,8 @@ type WatchConfig struct {
 	RPGMaxDirtyFilesPerBatch    int       `yaml:"rpg_max_dirty_files_per_batch,omitempty"`
 	// DiscoverWorktrees controls automatic discovery (and watching) of linked
 	// git worktrees. A pointer is used so that configs without the key keep
-	// the historical default (enabled).
+	// the historical default (enabled). Only the main worktree's config is
+	// consulted — the key is ignored in linked-worktree config copies.
 	DiscoverWorktrees *bool `yaml:"discover_worktrees,omitempty"`
 }
 

--- a/config/config_worktree_test.go
+++ b/config/config_worktree_test.go
@@ -144,3 +144,26 @@ func TestAutoInitFromMainWorktree(t *testing.T) {
 		}
 	})
 }
+
+func TestWatchConfig_WorktreeDiscoveryEnabled(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+
+	cases := []struct {
+		name string
+		val  *bool
+		want bool
+	}{
+		{name: "unset defaults to enabled", val: nil, want: true},
+		{name: "explicit true", val: boolPtr(true), want: true},
+		{name: "explicit false disables", val: boolPtr(false), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := WatchConfig{DiscoverWorktrees: tc.val}
+			if got := cfg.WorktreeDiscoveryEnabled(); got != tc.want {
+				t.Fatalf("WorktreeDiscoveryEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/config/config_worktree_test.go
+++ b/config/config_worktree_test.go
@@ -167,3 +167,35 @@ func TestWatchConfig_WorktreeDiscoveryEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestWatchConfig_DiscoverWorktreesSurvivesLoadSaveRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".grepai"), 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	yaml := "embedder:\n  provider: ollama\nstore:\n  backend: gob\nwatch:\n  debounce_ms: 500\n  discover_worktrees: false\n"
+	if err := os.WriteFile(filepath.Join(root, ".grepai", "config.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	// Explicit false must pass through YAML unmarshal...
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.Watch.WorktreeDiscoveryEnabled() {
+		t.Fatal("expected discovery disabled after Load")
+	}
+
+	// ...and survive the watcher's own config rewrite (Save + Load).
+	if err := cfg.Save(root); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+	cfg2, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load after Save failed: %v", err)
+	}
+	if cfg2.Watch.WorktreeDiscoveryEnabled() {
+		t.Fatal("expected discover_worktrees: false to survive Save/Load round-trip")
+	}
+}

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -58,6 +58,9 @@ chunking:
 watch:
   # Debounce delay in milliseconds
   debounce_ms: 500
+  # Auto-discover and watch linked git worktrees (default: true).
+  # Only read from the main worktree's config.
+  discover_worktrees: true
 
 # Call graph tracing configuration
 trace:

--- a/docs/src/content/docs/git-worktrees.md
+++ b/docs/src/content/docs/git-worktrees.md
@@ -102,11 +102,23 @@ This re-indexes only the files that differ from the copied seed index, keeping y
 
 If `config.yaml` is missing from the main worktree, auto-init will not proceed.
 
+### Disabling Worktree Discovery
+
+By default, `grepai watch` in the main worktree discovers all linked worktrees, auto-initializes them, and watches them alongside the main project. If you use many short-lived worktrees (e.g. AI-agent sessions) this multiplies indexing work and memory. Opt out in the **main worktree's** `.grepai/config.yaml`:
+
+```yaml
+watch:
+  discover_worktrees: false
+```
+
+The option is re-read on every discovery pass, so toggling it takes effect within seconds — no watcher restart needed. Worktrees already being watched are released on the next pass. The key is only consulted in the main worktree's config; setting it inside a linked worktree's copy has no effect. If the config can't be parsed, discovery is skipped for that pass (fail closed) and a warning is logged.
+
 ### Troubleshooting
 
 | Problem | Solution |
 |---------|----------|
-| Auto-init doesn't trigger | Verify the main worktree has `.grepai/config.yaml`. Run `grepai init` in the main worktree first. |
+| Auto-init doesn't trigger | Verify the main worktree has `.grepai/config.yaml`. Run `grepai init` in the main worktree first. Check that `watch.discover_worktrees` is not set to `false`. |
 | Search returns stale results | Run `grepai watch` in the linked worktree to update the index with worktree-specific changes. |
 | "not a git repository" error | Ensure `git` is installed and the directory is a valid git worktree. |
 | Want shared indexing | Switch to `postgres` or `qdrant` backend for cross-worktree index sharing. |
+| Too many worktrees indexed / high memory | Set `watch.discover_worktrees: false` in the main worktree's config (see above), or prune stale worktrees with `git worktree remove` + `git worktree prune`. |

--- a/docs/src/content/docs/watch-guide.md
+++ b/docs/src/content/docs/watch-guide.md
@@ -153,7 +153,11 @@ watch:
   rpg_persist_interval_ms: 1000
   rpg_full_reconcile_interval_sec: 300
   rpg_max_dirty_files_per_batch: 128
+  # Auto-discover and watch linked git worktrees (default: true)
+  discover_worktrees: true
 ```
+
+To watch only the main worktree, set `discover_worktrees: false` in the **main worktree's** config — see [Git Worktrees](/grepai/git-worktrees/#disabling-worktree-discovery).
 
 ### Persistence
 


### PR DESCRIPTION
## Problem

Fixes #211. `grepai watch` in a main worktree unconditionally discovers **all** linked git worktrees, auto-initializes them (creates `.grepai/`, edits their `.gitignore`) and watches them alongside the main project. There is no way to opt out.

For workflows that create many short-lived worktrees — AI-agent sessions, `git worktree`-based review checkouts — this multiplies indexing work, embedding calls and resident memory by the worktree count. The #211 author tried five separate workarounds (ignore patterns, per-worktree configs, killing sub-watchers…) — none work, because discovery is a separate mechanism from file scanning and ignores all of them.

## Change

One new key in `.grepai/config.yaml`, read in the main worktree:

```yaml
watch:
  discover_worktrees: false   # default: true
```

- **Backward compatible by construction**: the field is a `*bool` (`omitempty`), so existing configs — and configs rewritten by the watcher — keep the historical behavior (enabled) unless the user explicitly opts out. `WorktreeDiscoveryEnabled()` encapsulates the default.
- **Single choke point**: the guard lives inside `discoverWorktreesForWatch`, which is the sole entry to discovery, so the initial scan, the TUI path and the supervisor's periodic reconcile all respect it.
- **Live toggle**: the config is re-read on every discovery pass (3s reconcile), so flipping the option takes effect within seconds without restarting the watcher; already-watched worktrees are released on the next pass.
- **Fails closed**: if the config can't be loaded (e.g. a torn write while the user edits it between two reconcile passes), discovery is *skipped* for that pass and a warning is logged — a broken config can never silently re-enable the side-effectful auto-init the user opted out of.

## Tests

- main worktree discovers + auto-inits a linked worktree (baseline, key absent)
- `discover_worktrees: false` → no discovery, no auto-init side effects
- linked worktree never discovers siblings regardless of the option
- unreadable/torn config → fail closed, no discovery, no auto-init
- `WorktreeDiscoveryEnabled()` accessor: nil/true/false table test
- YAML round-trip: explicit `false` survives config load/save

## Docs

`configuration.md` and `watch-guide.md` now list the key; `git-worktrees.md` gains a "Disabling Worktree Discovery" section and two troubleshooting rows (discovery not triggering; too many worktrees indexed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
