### PR TITLE
fix(agents): honest tool-choice claims + recall-safe search combo in agent skill/template

### DIFF
--- a/.claude/skills/grepai/SKILL.md
+++ b/.claude/skills/grepai/SKILL.md
@@ -1,42 +1,47 @@
 ---
 name: grepai
-description: "Replaces ALL built-in search tools. You MUST invoke this skill BEFORE using WebSearch, Grep, or Glob. NEVER use the built-in Grep tool - use `grepai` instead."
+description: "Semantic code search and call-graph tracing. Use for intent questions ('where is authentication handled?'), exploring unfamiliar code, or tracing callers/callees — as a ranking layer on top of exact-match Grep, not a replacement for it."
 ---
 
-## CRITICAL: Tool Override for Semantic Searches
+## grepai: ranked semantic search (not a Grep replacement)
 
-This skill **REPLACES** built-in Grep/Glob tools for semantic code exploration.
+`grepai search` answers a natural-language query with ~10 scored chunks in one
+call — a ranked starting point at a fraction of the tokens of dumping raw grep
+output (`--json --compact` alone saves ~80%). It is a **ranking layer, not an
+exhaustive one**: a vector top-10 can miss a relevant file that keyword grep
+finds trivially. The rules below save tokens without losing recall.
 
-**WRONG**:
-- Using built-in `Grep` to find "where authentication happens"
-- Using built-in `Glob` to explore "error handling code"
-- Searching by intent with regex patterns
+## Tool Choice
 
-**CORRECT**:
-- Invoke this skill, then use `grepai search "authentication flow"` for semantic search
-- Invoke this skill, then use `grepai trace callers "FunctionName"` for call graph
-- Use built-in Grep/Glob ONLY for exact text matches (variable names, imports)
+| Query | Tool |
+|---|---|
+| Exact identifiers, imports, string literals | built-in Grep / `git grep` — fastest, exhaustive |
+| Intent with a canonical syntax anchor (`@main`, `func main(`, `class AppDelegate`) | Grep the anchor — many "intent" questions are exact-match queries in disguise |
+| Intent with no obvious anchor ("where are errors handled?") | recall-safe combo below |
+| Function relationships (callers/callees) | `grepai trace` — grep has no equivalent |
+| File patterns (`**/*.go`) | Glob |
 
-## When to Invoke This Skill
+## Recall-Safe Combo (cheap AND exhaustive)
 
-Invoke this skill **IMMEDIATELY** when:
+grep's token cost is in dumping content lines; its *recall* is nearly free when
+you ask for file names only. For an intent query, run both cheap layers:
 
-- User asks to find code by **intent** (e.g., "where is authentication handled?")
-- User asks to understand **what code does** (e.g., "how does the indexer work?")
-- User asks to explore **functionality** (e.g., "find error handling logic")
-- You need to understand **code relationships** (e.g., "what calls this function?")
-- User asks about **implementation details** (e.g., "how are vectors stored?")
+```bash
+# 1. Ranking: ~10 scored chunks, one call
+grepai search "where errors are handled and logged" --json --compact
 
-**DO NOT** use built-in Grep/Glob for intent-based searches. Use grepai instead.
+# 2. Recall: exhaustive candidate checklist — file NAMES only, ~zero tokens
+git grep -ilE 'error|handl|logg' | head -50
+```
 
-## When to Use Built-in Tools
+Read grepai's top hits first, then scan the checklist for relevant-looking
+files grepai did not rank — read those too. Never dump full grep content
+output for an intent query; the file list gives you grep's recall at ~1% of
+the tokens.
 
-Use Grep/Glob **ONLY** for:
-
-- Exact text matching: `Grep "func NewIndexer"` (find exact function name)
-- Specific imports: `Grep "import.*cobra"` (find import statements)
-- File patterns: `Glob "**/*.go"` (find files by extension)
-- Variable references: `Grep "configPath"` (find exact variable name)
+If grepai's top hits are docs/reports instead of code: scope with
+`grepai search "<query>" --path <srcdir>`, or add generated content to a
+`.grepaiignore`.
 
 ## How to Use This Skill
 
@@ -92,10 +97,10 @@ grepai search "HandleRequest"  # Use Grep for exact matches
 
 ## Recommended Workflow
 
-1. **Start with `grepai search`** to find relevant code semantically
-2. **Use `grepai trace`** to understand function relationships
-3. **Use `Read` tool** to examine files from search results
-4. **Use `Grep`** only for exact string searches if needed
+1. **Start with `grepai search`** for ranked starting points
+2. **Add `git grep -ilE '<keywords>'`** for the exhaustive file checklist (names only)
+3. **Use `grepai trace`** to understand function relationships
+4. **Use `Read`** on ranked hits first, then on relevant checklist files grepai did not rank
 
 ## Fallback
 
@@ -108,4 +113,4 @@ If grepai fails (not running, index unavailable, or errors), fall back to standa
 
 semantic search, code search, natural language search, find code, explore codebase,
 call graph, callers, callees, function relationships, code understanding,
-intent search, grep replacement, code exploration
+intent search, code exploration, recall, token savings

--- a/cli/agent_setup.go
+++ b/cli/agent_setup.go
@@ -29,6 +29,21 @@ Use ` + "`grepai search`" + ` INSTEAD OF Grep/Glob/find for:
 Only use Grep/Glob when you need:
 - Exact text matching (variable names, imports, specific strings)
 - File path patterns (e.g., ` + "`**/*.go`" + `)
+- Intent with a canonical syntax anchor (` + "`@main`" + `, ` + "`func main(`" + `) - an exact-match query in disguise
+
+### Completeness Check (recall-safe)
+
+grepai returns the top ~10 ranked chunks - a ranking, not an exhaustive list.
+When completeness matters (audits, refactors, "find ALL X"), pair it with a
+file-names-only grep - exhaustive recall at almost no token cost:
+
+` + "```bash" + `
+grepai search "where errors are handled" --json --compact   # ranked starting points
+git grep -ilE 'error|handl|logg' | head -50                 # exhaustive checklist (names only)
+` + "```" + `
+
+Read ranked hits first, then any relevant-looking checklist file grepai did
+not rank. Never dump full grep content output for an intent query.
 
 ### Fallback
 
@@ -88,10 +103,11 @@ grepai refs writers "uid" --json
 ### Workflow
 
 1. Start with ` + "`grepai search`" + ` to find relevant code
-2. Use ` + "`grepai trace`" + ` to understand function relationships
-3. Use ` + "`grepai refs`" + ` for property/state readers and writers
-4. Use ` + "`Read`" + ` tool to examine files from results
-5. Only use Grep for exact string searches if needed
+2. Add ` + "`git grep -ilE '<keywords>'`" + ` for the exhaustive file checklist when completeness matters
+3. Use ` + "`grepai trace`" + ` to understand function relationships
+4. Use ` + "`grepai refs`" + ` for property/state readers and writers
+5. Use ` + "`Read`" + ` tool to examine files from results
+6. Use Grep directly for exact strings and syntax anchors
 
 `
 


### PR DESCRIPTION
## Problem

The `.claude/skills/grepai/SKILL.md` skill tells agents:

> *"Replaces ALL built-in search tools. You MUST invoke this skill BEFORE using WebSearch, Grep, or Glob. NEVER use the built-in Grep tool"*

and the `agent-setup` template ends with *"Only use Grep for exact string searches if needed"*.

Measured on real repos, that claim doesn't hold — and it teaches agents a failure mode. `grepai search` returns the **top ~10 ranked chunks**: a ranking layer, not an exhaustive result set. On one measured repo it missed the ground-truth file on 2 of 3 intent queries (e.g. the `@main` app entry point absent from top-10, while `git grep '@main'` finds it in one hit — reproduced on two independent runs, with and without `--path` scoping). An agent told "NEVER use Grep" treats top-10 as complete coverage and **silently loses recall** — a missed relevant file is worse than a noisy one, because the agent believes it checked everything.

## Fix

Replace the override framing with guidance that keeps grepai's token savings **without losing recall**:

- **Recall-safe combo** for intent queries: `grepai search --json --compact` for ~10 ranked chunks **plus** `git grep -ilE '<keywords>'` for the exhaustive candidate file list. File names only ≈ grep's full recall at ~1% of the tokens of a content dump. Read ranked hits first, then relevant-looking checklist files grepai didn't rank.
- **Anchor queries go to grep**: many "intent" questions ("the main entry point") are exact-match queries in disguise (`@main`, `func main(`) — grep wins outright.
- **Docs pollution**: when top hits are markdown/reports instead of code, scope with `--path` or add a `.grepaiignore` (kept from existing docs).
- grepai stays the recommended first step for intent search, and `grepai trace` remains the only tool for call graphs.

## Changes

- `.claude/skills/grepai/SKILL.md` — rewritten claims + tool-choice table + recall-safe combo (command reference kept)
- `cli/agent_setup.go` — adds a "Completeness Check (recall-safe)" section and checklist step to the generated CLAUDE.md instructions (template text only, no logic)

`go build ./...` and `go test ./cli/` pass; existing `agent_setup` tests only assert markers/keywords and are unaffected.

Honest claims sell better: agents that never get burned by a silent miss keep using grepai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)