### PR TITLE
feat(embedder): add configurable batch_size

### DIFF
--- a/cli/watch.go
+++ b/cli/watch.go
@@ -995,6 +995,7 @@ func watchProjectWithEventObserver(ctx context.Context, projectRoot string, emb 
 
 	// Initialize indexer
 	idx := indexer.NewIndexer(projectRoot, st, emb, chunker, scanner, cfg.Watch.LastIndexTime, processorRegistry)
+	idx.SetBatchSize(cfg.Embedder.BatchSize)
 
 	// Initialize symbol store and extractor
 	symbolStore := trace.NewGOBSymbolStore(config.GetSymbolIndexPath(projectRoot))
@@ -2762,6 +2763,7 @@ func initializeWorkspaceRuntime(ctx context.Context, ws *config.Workspace, proje
 		projectPath:   project.Path,
 	}
 	idx := indexer.NewIndexer(project.Path, vectorStore, emb, chunker, scanner, projectCfg.Watch.LastIndexTime, processorRegistry)
+	idx.SetBatchSize(projectCfg.Embedder.BatchSize)
 	extractor := trace.NewRegexExtractor()
 	symbolStore := trace.NewGOBSymbolStore(config.GetSymbolIndexPath(project.Path))
 	if err := symbolStore.Load(ctx); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -111,7 +111,8 @@ type EmbedderConfig struct {
 	Endpoint    string `yaml:"endpoint,omitempty"`
 	APIKey      string `yaml:"api_key,omitempty"`
 	Dimensions  *int   `yaml:"dimensions,omitempty"`
-	Parallelism int    `yaml:"parallelism"` // Number of parallel workers for batch embedding (default: 4)
+	Parallelism int    `yaml:"parallelism"`          // Number of parallel workers for batch embedding (default: 4)
+	BatchSize   int    `yaml:"batch_size,omitempty"` // Max inputs per embedding request (default: 2000). Lower it for slow endpoints so a request stays under the client timeout.
 }
 
 // GetDimensions returns the configured dimensions or a default value.

--- a/docs/src/content/docs/backends/embedders.md
+++ b/docs/src/content/docs/backends/embedders.md
@@ -197,6 +197,26 @@ embedder:
 - On rate limit (429), parallelism auto-reduces and retries with backoff
 - After successful requests, parallelism gradually restores
 
+### Batch Size
+
+By default grepai packs up to `MaxBatchSize` (2000) inputs into each embedding
+request. For slow or self-hosted embedding endpoints, a large request can exceed
+the embedder's client timeout and fail the whole scan. Lower `batch_size` so each
+request stays under the timeout — indexing then runs as more, smaller requests
+(slower overall, but reliable). Pair it with `parallelism: 1` on throughput-bound
+endpoints, where concurrent requests just split a fixed throughput.
+
+```yaml
+embedder:
+  provider: openai
+  model: text-embedding-3-small
+  api_key: ${OPENAI_API_KEY}
+  parallelism: 1   # serialize on a slow, throughput-bound endpoint
+  batch_size: 20   # ~20 inputs per request keeps each call short
+```
+
+Values `<= 0` or above `MaxBatchSize` fall back to the default 2000.
+
 #### Recommended Parallelism by Tier
 
 Higher OpenAI tiers allow more concurrent requests. Use the table below as a starting point:

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -29,6 +29,9 @@ embedder:
   dimensions: 768
   # Concurrent batch requests for OpenAI (default: 4)
   parallelism: 4
+  # Max inputs per embedding request (default: 2000). Lower it for slow
+  # endpoints so a single request stays under the client timeout.
+  batch_size: 2000
 
 # Vector store configuration
 store:

--- a/embedder/batch.go
+++ b/embedder/batch.go
@@ -62,20 +62,22 @@ type batchBuilder struct {
 	batches       []Batch
 	current       Batch
 	currentTokens int
+	maxBatchSize  int
 }
 
-func newBatchBuilder(estimatedBatches int) *batchBuilder {
+func newBatchBuilder(estimatedBatches, maxBatchSize int) *batchBuilder {
 	return &batchBuilder{
-		batches: make([]Batch, 0, estimatedBatches),
+		maxBatchSize: maxBatchSize,
+		batches:      make([]Batch, 0, estimatedBatches),
 		current: Batch{
 			Index:   0,
-			Entries: make([]BatchEntry, 0, MaxBatchSize),
+			Entries: make([]BatchEntry, 0, maxBatchSize),
 		},
 	}
 }
 
 func (b *batchBuilder) isFull(additionalTokens int) bool {
-	if len(b.current.Entries) >= MaxBatchSize {
+	if len(b.current.Entries) >= b.maxBatchSize {
 		return true
 	}
 	if len(b.current.Entries) > 0 && b.currentTokens+additionalTokens > MaxBatchTokens {
@@ -88,7 +90,7 @@ func (b *batchBuilder) finalizeCurrent() {
 	b.batches = append(b.batches, b.current)
 	b.current = Batch{
 		Index:   len(b.batches),
-		Entries: make([]BatchEntry, 0, MaxBatchSize),
+		Entries: make([]BatchEntry, 0, b.maxBatchSize),
 	}
 	b.currentTokens = 0
 }
@@ -113,13 +115,26 @@ func (b *batchBuilder) build() []Batch {
 // MaxBatchSize (input count) and MaxBatchTokens (token limit).
 // Chunks maintain their file/chunk index tracking for result mapping.
 func FormBatches(files []FileChunks) []Batch {
+	return FormBatchesWithSize(files, MaxBatchSize)
+}
+
+// FormBatchesWithSize is like FormBatches but caps each batch at maxBatchSize
+// inputs instead of the default MaxBatchSize. A maxBatchSize <= 0 or greater than
+// MaxBatchSize falls back to MaxBatchSize (the API ceiling). Lowering it is useful
+// when the embedding endpoint is slow, so a single request stays under the embedder
+// client timeout. The MaxBatchTokens limit still applies.
+func FormBatchesWithSize(files []FileChunks, maxBatchSize int) []Batch {
+	if maxBatchSize <= 0 || maxBatchSize > MaxBatchSize {
+		maxBatchSize = MaxBatchSize
+	}
+
 	totalChunks := countTotalChunks(files)
 	if totalChunks == 0 {
 		return nil
 	}
 
-	estimatedBatches := (totalChunks + MaxBatchSize - 1) / MaxBatchSize
-	builder := newBatchBuilder(estimatedBatches)
+	estimatedBatches := (totalChunks + maxBatchSize - 1) / maxBatchSize
+	builder := newBatchBuilder(estimatedBatches, maxBatchSize)
 
 	for _, file := range files {
 		for chunkIdx, chunk := range file.Chunks {

--- a/embedder/batch_test.go
+++ b/embedder/batch_test.go
@@ -475,3 +475,51 @@ func TestFormBatches_SmallChunksIgnoreTokenLimit(t *testing.T) {
 		t.Errorf("first batch should have %d entries, got %d", MaxBatchSize, len(batches[0].Entries))
 	}
 }
+
+func TestFormBatchesWithSize_CustomSize(t *testing.T) {
+	chunks := make([]string, 77)
+	for i := range chunks {
+		chunks[i] = "chunk"
+	}
+	files := []FileChunks{{FileIndex: 0, Chunks: chunks}}
+
+	// 77 chunks capped at 20 per batch -> 20, 20, 20, 17.
+	batches := FormBatchesWithSize(files, 20)
+	if len(batches) != 4 {
+		t.Fatalf("expected 4 batches for 77 chunks at size 20, got %d", len(batches))
+	}
+	for i, want := range []int{20, 20, 20, 17} {
+		if got := len(batches[i].Entries); got != want {
+			t.Errorf("batch %d: expected %d entries, got %d", i, want, got)
+		}
+	}
+}
+
+func TestFormBatchesWithSize_FallbackToDefault(t *testing.T) {
+	chunks := make([]string, MaxBatchSize+10)
+	for i := range chunks {
+		chunks[i] = "chunk"
+	}
+	files := []FileChunks{{FileIndex: 0, Chunks: chunks}}
+
+	// n <= 0 or n > MaxBatchSize both fall back to MaxBatchSize.
+	for _, n := range []int{0, -5, MaxBatchSize + 100} {
+		batches := FormBatchesWithSize(files, n)
+		if len(batches[0].Entries) != MaxBatchSize {
+			t.Errorf("size %d: first batch should cap at %d, got %d", n, MaxBatchSize, len(batches[0].Entries))
+		}
+	}
+}
+
+// FormBatches must remain equivalent to FormBatchesWithSize(files, MaxBatchSize).
+func TestFormBatches_DelegatesToDefault(t *testing.T) {
+	chunks := make([]string, MaxBatchSize+50)
+	for i := range chunks {
+		chunks[i] = "chunk"
+	}
+	files := []FileChunks{{FileIndex: 0, Chunks: chunks}}
+
+	if got, want := len(FormBatches(files)), len(FormBatchesWithSize(files, MaxBatchSize)); got != want {
+		t.Errorf("FormBatches produced %d batches, FormBatchesWithSize(MaxBatchSize) produced %d", got, want)
+	}
+}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -19,6 +19,7 @@ type Indexer struct {
 	scanner       *Scanner
 	processor     *framework.ProcessorRegistry
 	lastIndexTime time.Time
+	batchSize     int
 }
 
 type IndexStats struct {
@@ -76,6 +77,17 @@ func NewIndexer(
 		scanner:       scanner,
 		processor:     processor,
 		lastIndexTime: lastIndexTime,
+		batchSize:     embedder.MaxBatchSize,
+	}
+}
+
+// SetBatchSize overrides the maximum number of inputs per embedding request for
+// this indexer. Values <= 0 (or above embedder.MaxBatchSize) are ignored, keeping
+// the default. Lower it for slow embedding endpoints so each request stays under
+// the embedder client timeout.
+func (idx *Indexer) SetBatchSize(n int) {
+	if n > 0 && n <= embedder.MaxBatchSize {
+		idx.batchSize = n
 	}
 }
 
@@ -418,7 +430,7 @@ func (idx *Indexer) indexFilesBatched(
 
 	// Embed remaining (non-cached) files
 	if len(remainingFileChunks) > 0 {
-		batches := embedder.FormBatches(remainingFileChunks)
+		batches := embedder.FormBatchesWithSize(remainingFileChunks, idx.batchSize)
 		results, err := batchEmb.EmbedBatches(ctx, batches, wrapBatchProgress(onProgress))
 		if err != nil {
 			return filesIndexed, chunksCreated, fmt.Errorf("failed to embed batches: %w", err)


### PR DESCRIPTION
## Summary

Adds an optional `embedder.batch_size` config option that caps the number of inputs per embedding API request. Default is `2000` (unchanged).

## Motivation

On slow or self-hosted OpenAI-compatible embedding endpoints, grepai's initial scan packs the entire batch (up to `MaxBatchSize` = 2000) into a single `/v1/embeddings` request. When the endpoint is slow, that one request exceeds the embedder's client timeout and the **whole initial index fails**:

```
initial indexing failed: failed to embed batches: failed to send request to OpenAI:
Post ".../v1/embeddings": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

There is currently no config-level way to work around this. Lowering `batch_size` keeps each request short so indexing completes reliably as more, smaller requests (slower overall, but it finishes). On throughput-bound endpoints it pairs well with `parallelism: 1`.

```yaml
embedder:
  provider: openai
  endpoint: http://my-slow-gateway:4000/v1
  model: qwen3-embedding-8b
  parallelism: 1
  batch_size: 20
```

## Changes

- **config**: `EmbedderConfig.BatchSize` (`yaml: batch_size`)
- **embedder**: additive `FormBatchesWithSize(files, maxBatchSize)`; `FormBatches` now delegates to it with the `MaxBatchSize` default (no behavior change). Values `<= 0` or `> MaxBatchSize` fall back to the default.
- **indexer**: per-`Indexer` `batchSize` (defaults to `MaxBatchSize`) + `SetBatchSize`; the batched embed path uses `FormBatchesWithSize`.
- **cli/watch**: applies `cfg.Embedder.BatchSize` to the indexer for both the single-project and workspace paths.
- Tests (`FormBatchesWithSize` custom size, default fallback, `FormBatches` delegation) and docs.

## Backward compatibility

Fully backward compatible. Unset / `<= 0` / `> MaxBatchSize` all use the existing 2000 default; `FormBatches` behaves exactly as before. The `MaxBatchTokens` limit still applies.

## Testing

```
go build ./cmd/grepai
go test ./embedder/... ./config/... ./indexer/...   # all pass
gofmt -l ...                                         # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
