### PR TITLE
ci: align Go matrix with go.mod (1.24/1.25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.25"
           cache: true
 
       - name: golangci-lint
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ["1.22", "1.23"]
+        go-version: ["1.24", "1.25"]
     steps:
       - uses: actions/checkout@v7
 
@@ -53,7 +53,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.22'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24'
         uses: codecov/codecov-action@v7
         with:
           files: coverage.out
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.25"
           cache: true
 
       - name: Build


### PR DESCRIPTION
## Problem

The CI matrix tested Go **1.22 and 1.23** while `go.mod` already required **1.24.2**, and lint/build pinned **1.22**.

Those jobs only passed because Go silently downloads the required toolchain. So the matrix was not testing the versions it claimed to test, and a `go.mod` bump could break CI in ways the matrix itself could not anticipate.

That is exactly what happened earlier today with mcp-go 0.54.0 (#242, reverted in #281). Raising the directive to 1.25.5 broke:

```
Lint:  can't load config: the Go language version (go1.24) used to build
       golangci-lint is lower than the targeted Go version (1.25.5)

Test:  # github.com/yoanbernabeu/grepai/cmd/grepai
       go: no such tool "covdata"
```

## Change

| | before | after |
|---|---|---|
| Test matrix | `["1.22", "1.23"]` | `["1.24", "1.25"]` |
| Lint | `1.22` | `1.25` |
| Build | `1.22` | `1.25` |
| Coverage upload condition | `go-version == '1.22'` | `go-version == '1.24'` |

The coverage condition has to follow the matrix, otherwise it would silently never fire again.

## Consequence

grepai no longer advertises support for Go 1.22/1.23 — which is already the de-facto situation, since `go.mod` requires 1.24.2 and building on 1.22 only works via toolchain download.

## Unblocks

Three dependency bumps that require Go 1.25 and are currently unmergeable:

- #253 qdrant/go-client → 1.19.0
- #254 pgvector-go → 0.4.1
- #228 pgx/v5 → 5.10.0