### PR TITLE
style: gofmt indexer/scanner_test.go

### DIFF
--- a/indexer/scanner_test.go
+++ b/indexer/scanner_test.go
@@ -388,7 +388,7 @@ func TestScanner_CustomExtensions(t *testing.T) {
 
 	// File with a custom extension that's not in SupportedExtensions.
 	tengoFile := filepath.Join(tmpDir, "workflow.tengo")
-	if err := os.WriteFile(tengoFile, []byte(`fmt := import("fmt")` + "\n" + `fmt.println("hello")` + "\n"), 0644); err != nil {
+	if err := os.WriteFile(tengoFile, []byte(`fmt := import("fmt")`+"\n"+`fmt.println("hello")`+"\n"), 0644); err != nil {
 		t.Fatalf("failed to create tengo file: %v", err)
 	}
 


### PR DESCRIPTION
## Problem

The Lint job on `main` has been failing since 2a56fdd (#256):

```
indexer/scanner_test.go:391:1: File is not properly formatted (gofmt)
```

All 6 test jobs pass — this is purely a formatting violation.

## Fix

`gofmt -w indexer/scanner_test.go`, which removes the spaces around `+` in a string concatenation. One line, test-only, no behaviour change.

`gofmt -l .` is now clean across the repo.