### PR TITLE
ci: drop Go 1.24 from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ["1.24", "1.25"]
+        go-version: ["1.25"]
     steps:
       - uses: actions/checkout@v7
 
@@ -53,7 +53,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.24'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25'
         uses: codecov/codecov-action@v7
         with:
           files: coverage.out


### PR DESCRIPTION
## Why

Three pending dependency bumps all require Go 1.25, and each raises the `go` directive in `go.mod` to `1.25.0`:

- #253 qdrant/go-client → 1.19.0
- #254 pgvector-go → 0.4.1
- #228 pgx/v5 → 5.10.0

A module requiring `go 1.25.0` cannot be built by the 1.24 matrix job. Confirmed empirically on #253's CI, running against the 1.24/1.25 matrix introduced in #284:

| job | result |
|---|---|
| Test (ubuntu-latest, 1.25) | success |
| Test (macos-latest, 1.25) | success |
| Test (ubuntu-latest, 1.24) | **failure** |
| Test (macos-latest, 1.24) | **failure** |

So the choice is binary: keep 1.24 and freeze those three dependencies indefinitely, or narrow the matrix to 1.25 and take them.

## Change

| | before | after |
|---|---|---|
| Test matrix | `["1.24", "1.25"]` | `["1.25"]` |
| Coverage upload condition | `go-version == '1.24'` | `go-version == '1.25'` |

Lint and build already pin 1.25 (#284), so this makes the whole pipeline consistent on a single version.

## Consequence

grepai now requires **Go 1.25+**. Worth a note in the README / release notes when the next version ships.

Follow-up to #284, which aligned the matrix with `go.mod` but kept 1.24.