### PR TITLE
fix(ci): use go-version-file in docs and release workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
 
       - name: Generate Cobra docs
         run: go run cmd/gendocs/main.go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
           cache: true
 
       - name: Run GoReleaser


### PR DESCRIPTION
The setup-go v7 bump (#292) enforces GOTOOLCHAIN=local, so the Go versions pinned in docs.yml (1.24) and release.yml (1.22) can no longer auto-upgrade to satisfy go.mod (go >= 1.25). This broke the Deploy Documentation workflow on main and would have broken the next release.

Point both workflows at `go-version-file: go.mod` so they always match the module requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgxibmTpYs5e851sugKPhZ