### PR TITLE
docs(changelog): document the symbol cache invalidation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale Symbols After Upgrade**: Pair each persisted symbol entry with the extractor version that produced it, so a release shipping improved symbol extraction re-processes unchanged files instead of leaving stale symbols in place until `.grepai/symbols.gob` is deleted by hand (#264) - @kryptt
+  - The first `grepai watch` after upgrading re-extracts symbols for every traced file once, then returns to normal incremental behaviour
+  - Symbol extraction only: the vector index is untouched and **no re-embedding occurs**, so there is no API cost and no reindexing to plan
+  - Existing `symbols.gob` files load unchanged, and remain readable if you downgrade
+
 ## [0.36.0] - 2026-08-30
 
 ### Added


### PR DESCRIPTION
Adds the `Unreleased` entry for #264, which was merged without one.

The upgrade note matters as much as the fix itself: after upgrading, users will see `Symbol index built: N symbols extracted` on a project whose files they never touched. Without an explanation, that reads as a regression — or worse, as a surprise embedding bill. The entry states explicitly that this is local parsing, that the vector index is untouched, and that no re-embedding occurs.

Also notes that existing `symbols.gob` files load unchanged and stay readable after a downgrade — both directions were verified by round-tripping real gob files between the pre-#264 and post-#264 encoders.

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgxibmTpYs5e851sugKPhZ